### PR TITLE
Generate Python dataclasses from Go status structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -798,3 +798,8 @@ docs-%:
 ## docs-run: Build and serve the documentation
 ## docs-clean: Clean the docs build artifacts
 	cd docs && $(MAKE) -f Makefile.sp sp-$* ALLFILES='*.md **/*.md'
+
+.PHONY: getfields
+getfields:
+	go run ./cmd/getfields/ >structs.py
+	uvx ruff@0.9.6 format --line-length=99 --config "format.quote-style = 'single'" structs.py

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
+// TODO: compare with Juju 4.x/main branch
 // TODO: look closely at remaining "| None = None" fields
 // TODO: class StorageAttachments:
 //    units: dict[str, UnitStorageAttachment] # <-- should this and non-omitempty lists have defaults?

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,6 +13,12 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
+// TODO: get rid of "bool | None" types
+// TODO: consider making default for "str | None" just '' -- look over them first
+// TODO: ad-hoc for struct fields
+// TODO: make dataclasses frozen
+// TODO: handle Err field ("error-status") by raising
+
 func main() {
 	structs := status.GetFields()
 
@@ -44,7 +50,14 @@ func main() {
 				}
 			}
 			if field.OmitEmpty {
-				pythonType += " | None = None"
+				switch {
+				case strings.HasPrefix(pythonType, "list["):
+					pythonType += " = dataclasses.field(default_factory=list)"
+				case strings.HasPrefix(pythonType, "dict[str, "):
+					pythonType += " = dataclasses.field(default_factory=dict)"
+				default:
+					pythonType += " | None = None"
+				}
 			}
 			line := fmt.Sprintf("    %s: %s\n", pythonField, pythonType)
 			if field.OmitEmpty {
@@ -145,11 +158,26 @@ func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
 	orig := s
 	s = doType(pythonType, s)
 	if omitEmpty {
+		// TODO: [] and {} for list and dict
 		if s == orig {
 			// shortcut for simple value lookup
-			return fmt.Sprintf("d.get('%s')", jsonField)
+			switch {
+			case strings.HasPrefix(pythonType, "list["):
+				return fmt.Sprintf("d.get('%s') or []", jsonField)
+			case strings.HasPrefix(pythonType, "dict[str, "):
+				return fmt.Sprintf("d.get('%s') or {}", jsonField)
+			default:
+				return fmt.Sprintf("d.get('%s')", jsonField)
+			}
 		}
-		s += fmt.Sprintf(" if '%s' in d else None", jsonField)
+		switch {
+		case strings.HasPrefix(pythonType, "list["):
+			s += fmt.Sprintf(" if '%s' in d else []", jsonField)
+		case strings.HasPrefix(pythonType, "dict[str, "):
+			s += fmt.Sprintf(" if '%s' in d else {}", jsonField)
+		default:
+			s += fmt.Sprintf(" if '%s' in d else None", jsonField)
+		}
 	}
 	return s
 }

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
-// TODO: look closely at remaining "| None = None" fields
 // TODO: what exception to raise for status-error?
 
 func main() {

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
-// TODO: get rid of "bool | None" types
 // TODO: consider making default for "str | None" just '' -- look over them first
 // TODO: ad-hoc for struct fields
 // TODO: make dataclasses frozen
@@ -55,6 +54,8 @@ func main() {
 					pythonType += " = dataclasses.field(default_factory=list)"
 				case strings.HasPrefix(pythonType, "dict[str, "):
 					pythonType += " = dataclasses.field(default_factory=dict)"
+				case pythonType == "bool":
+					pythonType += " = False"
 				default:
 					pythonType += " | None = None"
 				}
@@ -166,6 +167,8 @@ func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
 				return fmt.Sprintf("d.get('%s') or []", jsonField)
 			case strings.HasPrefix(pythonType, "dict[str, "):
 				return fmt.Sprintf("d.get('%s') or {}", jsonField)
+			case pythonType == "bool":
+				return fmt.Sprintf("d.get('%s') or False", jsonField)
 			default:
 				return fmt.Sprintf("d.get('%s')", jsonField)
 			}
@@ -175,6 +178,8 @@ func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
 			s += fmt.Sprintf(" if '%s' in d else []", jsonField)
 		case strings.HasPrefix(pythonType, "dict[str, "):
 			s += fmt.Sprintf(" if '%s' in d else {}", jsonField)
+		case pythonType == "bool":
+			s += fmt.Sprintf(" if '%s' in d else False", jsonField)
 		default:
 			s += fmt.Sprintf(" if '%s' in d else None", jsonField)
 		}

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
-// TODO: improve ruff formatting with line-length=99
+const maxLineLength = 99
 
 func main() {
 	structs := status.GetFields()
@@ -131,7 +131,12 @@ func main() {
 			pythonField := getPythonField(field.JSONField)
 			pythonType, _ := getPythonType(structs, field.Type)
 			dictGetter := getDictGetter(pythonType, field.JSONField, field.OmitEmpty, requireArgsStructs[pythonType])
-			fmt.Fprintf(&buf, "            %s=%s,\n", pythonField, dictGetter)
+			line := fmt.Sprintf("            %s=%s,", pythonField, dictGetter)
+			if len(line) > maxLineLength {
+				// So that Ruff formats these lines nicely
+				line = fmt.Sprintf("            %s=(%s),", pythonField, dictGetter)
+			}
+			fmt.Fprintln(&buf, line)
 		}
 		fmt.Fprintln(&buf, "        )")
 

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
+// TODO: field Attachments needs lowercase
+
 const maxLineLength = 99
 
 var additionalMethods = map[string]string{
@@ -174,6 +176,8 @@ func main() {
 		}
 
 		fmt.Fprintln(&buf, "        return cls(")
+		optional = optional[:0]
+		required = required[:0]
 		for _, field := range structs[name] {
 			if field.JSONField == "" {
 				if field.Name == "Err" && field.Type == "error" {
@@ -190,8 +194,20 @@ func main() {
 				// So that Ruff formats these lines nicely
 				line = fmt.Sprintf("            %s=(%s),", pythonField, dictGetter)
 			}
-			fmt.Fprintln(&buf, line)
+			if field.OmitEmpty {
+				optional = append(optional, line+"\n")
+			} else {
+				required = append(required, line+"\n")
+			}
 		}
+
+		for _, line := range required {
+			fmt.Fprint(&buf, line)
+		}
+		for _, line := range optional {
+			fmt.Fprint(&buf, line)
+		}
+
 		fmt.Fprintln(&buf, "        )")
 
 		if methods, ok := additionalMethods[className]; ok {

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -152,6 +152,7 @@ func main() {
 	fmt.Print(`"""Dataclasses used to hold parsed output from "juju status --format=json"."""
 
 from __future__ import annotations
+
 import dataclasses
 from typing import Any
 

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
-// TODO: consider making default for "str | None" just '' -- look over them first
 // TODO: ad-hoc for struct fields
 // TODO: what exception to raise for status-error?
 //       see message in Matrix: juju-dev: https://matrix.to/#/!wJiiHsLipVywuWOyNi:ubuntu.com/$NMDdkF7koi7MrCQ6lLCKLduhk8IX3sNZlV2bGP6kuNc?via=ubuntu.com&via=matrix.org
@@ -59,6 +58,10 @@ func main() {
 					pythonType += " = dataclasses.field(default_factory=dict)"
 				case pythonType == "bool":
 					pythonType += " = False"
+				case pythonType == "str":
+					pythonType += " = ''"
+				case pythonType == "int":
+					pythonType += " = 0"
 				default:
 					pythonType += " | None = None"
 				}
@@ -182,7 +185,6 @@ func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
 	orig := s
 	s = doType(pythonType, s)
 	if omitEmpty {
-		// TODO: [] and {} for list and dict
 		if s == orig {
 			// shortcut for simple value lookup
 			switch {
@@ -192,6 +194,10 @@ func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
 				return fmt.Sprintf("d.get('%s') or {}", jsonField)
 			case pythonType == "bool":
 				return fmt.Sprintf("d.get('%s') or False", jsonField)
+			case pythonType == "str":
+				return fmt.Sprintf("d.get('%s') or ''", jsonField)
+			case pythonType == "int":
+				return fmt.Sprintf("d.get('%s') or 0", jsonField)
 			default:
 				return fmt.Sprintf("d.get('%s')", jsonField)
 			}
@@ -203,6 +209,10 @@ func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
 			s += fmt.Sprintf(" if '%s' in d else {}", jsonField)
 		case pythonType == "bool":
 			s += fmt.Sprintf(" if '%s' in d else False", jsonField)
+		case pythonType == "str":
+			s += fmt.Sprintf(" if '%s' in d else ''", jsonField)
+		case pythonType == "int":
+			s += fmt.Sprintf(" if '%s' in d else 0", jsonField)
 		default:
 			s += fmt.Sprintf(" if '%s' in d else None", jsonField)
 		}

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -28,6 +28,8 @@ func main() {
 		className = strings.ReplaceAll(className, "Application", "App")
 		fmt.Fprintf(&buf, "class %s:\n", className)
 		successors[className] = nil
+		var required []string
+		var optional []string
 		for _, field := range structs[name] {
 			pythonField := getPythonField(field.JSONField)
 			pythonType := ""
@@ -42,9 +44,23 @@ func main() {
 				}
 			}
 			if field.OmitEmpty {
-				pythonType += " | None"
+				pythonType += " | None = None"
 			}
-			fmt.Fprintf(&buf, "    %s: %s\n", pythonField, pythonType)
+			line := fmt.Sprintf("    %s: %s\n", pythonField, pythonType)
+			if field.OmitEmpty {
+				optional = append(optional, line)
+			} else {
+				required = append(required, line)
+			}
+		}
+		for _, line := range required {
+			fmt.Fprint(&buf, line)
+		}
+		if len(required) > 0 && len(optional) > 0 {
+			fmt.Fprintln(&buf)
+		}
+		for _, line := range optional {
+			fmt.Fprint(&buf, line)
 		}
 
 		fmt.Fprintf(&buf, "\n    @classmethod\n")

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
-// TODO: what exception to raise for status-error?
+// TODO: improve ruff formatting with line-length=99
 
 func main() {
 	structs := status.GetFields()
@@ -116,7 +116,7 @@ func main() {
 		// UnitStatus is a special case, has Err as .WorkloadStatusInfo.Err
 		if hasErr || className == "UnitStatus" {
 			fmt.Fprintln(&buf, "        if 'status-error' in d:")
-			fmt.Fprintln(&buf, "            raise Exception(d['status-error'])")
+			fmt.Fprintln(&buf, "            raise StatusError(d['status-error'])")
 		}
 
 		fmt.Fprintln(&buf, "        return cls(")
@@ -146,9 +146,16 @@ func main() {
 		}
 		order = append(order, names[0])
 	}
-	fmt.Println("from __future__ import annotations")
-	fmt.Println("import dataclasses")
-	fmt.Println("from typing import Any")
+	fmt.Print(`"""Dataclasses used to hold parsed output from "juju status --format=json"."""
+
+from __future__ import annotations
+import dataclasses
+from typing import Any
+
+
+class StatusError(Exception):
+    """Raised when "juju status" returns a status-error for certain types."""
+`)
 	for _, name := range order {
 		fmt.Print(classes[name])
 	}

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -270,6 +270,7 @@ func getClassName(goType string) string {
 func getPythonField(s string) string {
 	s = strings.ReplaceAll(s, "-", "_")
 	s = strings.ReplaceAll(s, "application", "app")
+	s = strings.ToLower(s)
 	return s
 }
 

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -15,7 +15,8 @@ import (
 
 // TODO: consider making default for "str | None" just '' -- look over them first
 // TODO: ad-hoc for struct fields
-// TODO: handle Err field ("error-status") by raising
+// TODO: what exception to raise for status-error?
+//       see message in Matrix: juju-dev: https://matrix.to/#/!wJiiHsLipVywuWOyNi:ubuntu.com/$NMDdkF7koi7MrCQ6lLCKLduhk8IX3sNZlV2bGP6kuNc?via=ubuntu.com&via=matrix.org
 
 func main() {
 	structs := status.GetFields()
@@ -35,6 +36,9 @@ func main() {
 		var required []string
 		var optional []string
 		for _, field := range structs[name] {
+			if field.JSONField == "" {
+				continue
+			}
 			pythonField := getPythonField(field.JSONField)
 			pythonType := ""
 			if _, ok := structs[field.Type]; ok {
@@ -78,8 +82,28 @@ func main() {
 
 		fmt.Fprintf(&buf, "\n    @classmethod\n")
 		fmt.Fprintf(&buf, "    def from_dict(cls, d: dict[str, Any]) -> %s:\n", className)
+
+		hasErr := false
+		for _, field := range structs[name] {
+			if field.JSONField == "" && field.Name == "Err" && field.Type == "error" {
+				hasErr = true
+			}
+		}
+		// UnitStatus is a special case, has Err as .WorkloadStatusInfo.Err
+		if hasErr || className == "UnitStatus" {
+			fmt.Fprintln(&buf, "        if 'status-error' in d:")
+			fmt.Fprintln(&buf, "            raise Exception(d['status-error'])")
+		}
+
 		fmt.Fprintln(&buf, "        return cls(")
 		for _, field := range structs[name] {
+			if field.JSONField == "" {
+				if field.Name == "Err" && field.Type == "error" {
+					continue
+				}
+				fmt.Fprintf(os.Stderr, "skipped field: %s.%s %s\n", name, field.Name, field.Type)
+				continue
+			}
 			pythonField := getPythonField(field.JSONField)
 			pythonType, _ := getPythonType(structs, field.Type)
 			dictGetter := getDictGetter(pythonType, field.JSONField, field.OmitEmpty)

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,8 +13,6 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
-// TODO: field Attachments needs lowercase
-
 const maxLineLength = 99
 
 var additionalMethods = map[string]string{

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -40,9 +40,9 @@ func main() {
 				if base != "" {
 					successors[className] = append(successors[className], base)
 				}
-				if field.OmitEmpty {
-					pythonType += " | None"
-				}
+			}
+			if field.OmitEmpty {
+				pythonType += " | None"
 			}
 			fmt.Fprintf(&buf, "    %s: %s\n", pythonField, pythonType)
 		}

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/juju/juju/cmd/juju/status"
+)
+
+func main() {
+	structs := status.GetFields()
+
+	classes := make(map[string]string)
+	successors := make(map[string][]string)
+
+	structNames := slices.Sorted(maps.Keys(structs))
+	for _, name := range structNames {
+		var buf bytes.Buffer
+
+		fmt.Fprintln(&buf, "\n\n@dataclasses.dataclass")
+		className := strings.Title(name)
+		className = strings.ReplaceAll(className, "Application", "App")
+		fmt.Fprintf(&buf, "class %s:\n", className)
+		successors[className] = nil
+		for _, field := range structs[name] {
+			pythonField := getPythonField(field.JSONField)
+			pythonType := ""
+			if _, ok := structs[field.Type]; ok {
+				pythonType, _ = getPythonType(structs, field.Type)
+				successors[className] = append(successors[className], pythonType)
+			} else {
+				var base string
+				pythonType, base = getPythonType(structs, field.Type)
+				if base != "" {
+					successors[className] = append(successors[className], base)
+				}
+				if field.OmitEmpty {
+					pythonType += " | None"
+				}
+			}
+			fmt.Fprintf(&buf, "    %s: %s\n", pythonField, pythonType)
+		}
+
+		fmt.Fprintf(&buf, "\n    @classmethod\n")
+		fmt.Fprintf(&buf, "    def from_dict(cls, d: dict[str, Any]) -> %s:\n", className)
+		fmt.Fprintln(&buf, "        return cls(")
+		for _, field := range structs[name] {
+			pythonField := getPythonField(field.JSONField)
+			pythonType, _ := getPythonType(structs, field.Type)
+			dictGetter := getDictGetter(pythonType, field.JSONField, field.OmitEmpty)
+			fmt.Fprintf(&buf, "            %s=%s,\n", pythonField, dictGetter)
+		}
+		fmt.Fprintln(&buf, "        )")
+
+		classes[className] = buf.String()
+		buf.Reset()
+	}
+
+	var order []string
+	for _, names := range tarjanSort(successors) {
+		if len(names) > 1 {
+			panic(fmt.Sprintf("dependency loop: %s", strings.Join(names, ", ")))
+		}
+		order = append(order, names[0])
+	}
+	fmt.Println("from __future__ import annotations")
+	fmt.Println("import dataclasses")
+	fmt.Println("from typing import Any")
+	for _, name := range order {
+		fmt.Print(classes[name])
+	}
+
+	f, err := os.Create("structs.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+	b, err := json.MarshalIndent(structs, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = f.Write(b)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = f.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func getPythonField(s string) string {
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, "application", "app")
+	return s
+}
+
+func getPythonType(structs map[string][]status.FieldInfo, goType string) (string, string) {
+	switch {
+	case strings.HasPrefix(goType, "[]"):
+		inner, base := getPythonType(structs, goType[2:])
+		return "list[" + inner + "]", base
+	case strings.HasPrefix(goType, "map[string]"):
+		inner, base := getPythonType(structs, goType[11:])
+		return "dict[str, " + inner + "]", base
+	case goType == "string":
+		return "str", ""
+	case goType == "bool":
+		return "bool", ""
+	case goType == "int" || goType == "uint64":
+		return "int", ""
+	default:
+		if _, ok := structs[goType]; !ok {
+			fmt.Fprintf(os.Stderr, "# unhandled Go type: %s\n", goType)
+		}
+		pythonType := strings.Title(goType)
+		pythonType = strings.ReplaceAll(pythonType, "Application", "App")
+		return pythonType, pythonType
+	}
+}
+
+func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
+	s := fmt.Sprintf("d['%s']", jsonField)
+	orig := s
+	s = doType(pythonType, s)
+	if omitEmpty {
+		if s == orig {
+			// shortcut for simple value lookup
+			return fmt.Sprintf("d.get('%s')", jsonField)
+		}
+		s += fmt.Sprintf(" if '%s' in d else None", jsonField)
+	}
+	return s
+}
+
+func doType(pythonType string, value string) string {
+	switch {
+	case strings.HasPrefix(pythonType, "list["):
+		t := pythonType[5 : len(pythonType)-1]
+		return fmt.Sprintf("[%s for x in %s]", doType(t, "x"), value)
+	case strings.HasPrefix(pythonType, "dict[str, "):
+		t := pythonType[10 : len(pythonType)-1]
+		return fmt.Sprintf("{k: %s for k, v in %s.items()}", doType(t, "v"), value)
+	case pythonType == "str" || pythonType == "int" || pythonType == "bool":
+		return value
+	default:
+		return fmt.Sprintf("%s.from_dict(%s)", pythonType, value)
+	}
+}

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -96,11 +96,13 @@ func main() {
 		}
 	}
 
+	var allNames []string
 	for _, name := range structNames {
 		var buf bytes.Buffer
 
 		fmt.Fprintln(&buf, "\n\n@dataclasses.dataclass(frozen=True, kw_only=True)")
 		className := getClassName(name)
+		allNames = append(allNames, className)
 		fmt.Fprintf(&buf, "class %s:\n", className)
 		successors[className] = nil
 		var required []string
@@ -223,12 +225,24 @@ func main() {
 		}
 		order = append(order, names[0])
 	}
+
+	allNames = append(allNames, "StatusError")
+	slices.Sort(allNames)
+
 	fmt.Print(`"""Dataclasses used to hold parsed output from "juju status --format=json"."""
 
 from __future__ import annotations
 
 import dataclasses
 from typing import Any
+
+__all__ = [
+`)
+	for _, name := range allNames {
+		fmt.Printf("    \"%s\",\n", name)
+	}
+	fmt.Print(`
+]
 
 
 class StatusError(Exception):

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -142,10 +142,18 @@ func doType(pythonType string, value string) string {
 	switch {
 	case strings.HasPrefix(pythonType, "list["):
 		t := pythonType[5 : len(pythonType)-1]
-		return fmt.Sprintf("[%s for x in %s]", doType(t, "x"), value)
+		inner := doType(t, "x")
+		if inner == "x" {
+			return value
+		}
+		return fmt.Sprintf("[%s for x in %s]", inner, value)
 	case strings.HasPrefix(pythonType, "dict[str, "):
 		t := pythonType[10 : len(pythonType)-1]
-		return fmt.Sprintf("{k: %s for k, v in %s.items()}", doType(t, "v"), value)
+		inner := doType(t, "v")
+		if inner == "v" {
+			return value
+		}
+		return fmt.Sprintf("{k: %s for k, v in %s.items()}", inner, value)
 	case pythonType == "str" || pythonType == "int" || pythonType == "bool":
 		return value
 	default:

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -34,8 +34,7 @@ func main() {
 				requireArgs = true
 			}
 		}
-		className := strings.Title(name)
-		className = strings.ReplaceAll(className, "Application", "App")
+		className := getClassName(name)
 		if requireArgs {
 			requireArgsStructs[className] = requireArgs
 		}
@@ -45,8 +44,7 @@ func main() {
 		var buf bytes.Buffer
 
 		fmt.Fprintln(&buf, "\n\n@dataclasses.dataclass(frozen=True, kw_only=True)")
-		className := strings.Title(name)
-		className = strings.ReplaceAll(className, "Application", "App")
+		className := getClassName(name)
 		fmt.Fprintf(&buf, "class %s:\n", className)
 		successors[className] = nil
 		var required []string
@@ -183,6 +181,15 @@ class StatusError(Exception):
 	}
 }
 
+func getClassName(goType string) string {
+	className := strings.Title(goType)
+	className = strings.ReplaceAll(className, "Application", "App")
+	if className == "FormattedStatus" {
+		className = "Status"
+	}
+	return className
+}
+
 func getPythonField(s string) string {
 	s = strings.ReplaceAll(s, "-", "_")
 	s = strings.ReplaceAll(s, "application", "app")
@@ -207,8 +214,7 @@ func getPythonType(structs map[string][]status.FieldInfo, goType string) (string
 		if _, ok := structs[goType]; !ok {
 			fmt.Fprintf(os.Stderr, "# unhandled Go type: %s\n", goType)
 		}
-		pythonType := strings.Title(goType)
-		pythonType = strings.ReplaceAll(pythonType, "Application", "App")
+		pythonType := getClassName(goType)
 		return pythonType, pythonType
 	}
 }

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -15,7 +15,6 @@ import (
 
 // TODO: consider making default for "str | None" just '' -- look over them first
 // TODO: ad-hoc for struct fields
-// TODO: make dataclasses frozen
 // TODO: handle Err field ("error-status") by raising
 
 func main() {
@@ -28,7 +27,7 @@ func main() {
 	for _, name := range structNames {
 		var buf bytes.Buffer
 
-		fmt.Fprintln(&buf, "\n\n@dataclasses.dataclass")
+		fmt.Fprintln(&buf, "\n\n@dataclasses.dataclass(frozen=True)")
 		className := strings.Title(name)
 		className = strings.ReplaceAll(className, "Application", "App")
 		fmt.Fprintf(&buf, "class %s:\n", className)

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -15,6 +15,10 @@ import (
 
 const maxLineLength = 99
 
+var classDocstrings = map[string]string{
+	"Status": `Parsed version of the status object returned by "juju status --format=json".`,
+}
+
 var additionalMethods = map[string]string{
 	"AppStatus": `
     @property
@@ -104,6 +108,9 @@ func main() {
 		className := getClassName(name)
 		allNames = append(allNames, className)
 		fmt.Fprintf(&buf, "class %s:\n", className)
+		if docstring, ok := classDocstrings[className]; ok {
+			fmt.Fprintf(&buf, `    """%s"""`+"\n", docstring)
+		}
 		successors[className] = nil
 		var required []string
 		var optional []string

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,12 +13,8 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
-// TODO: compare with Juju 4.x/main branch
 // TODO: look closely at remaining "| None = None" fields
-// TODO: class StorageAttachments:
-//    units: dict[str, UnitStorageAttachment] # <-- should this and non-omitempty lists have defaults?
 // TODO: what exception to raise for status-error?
-//       see message in Matrix: juju-dev: https://matrix.to/#/!wJiiHsLipVywuWOyNi:ubuntu.com/$NMDdkF7koi7MrCQ6lLCKLduhk8IX3sNZlV2bGP6kuNc?via=ubuntu.com&via=matrix.org
 
 func main() {
 	structs := status.GetFields()
@@ -49,7 +45,7 @@ func main() {
 	for _, name := range structNames {
 		var buf bytes.Buffer
 
-		fmt.Fprintln(&buf, "\n\n@dataclasses.dataclass(frozen=True)")
+		fmt.Fprintln(&buf, "\n\n@dataclasses.dataclass(frozen=True, kw_only=True)")
 		className := strings.Title(name)
 		className = strings.ReplaceAll(className, "Application", "App")
 		fmt.Fprintf(&buf, "class %s:\n", className)

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -15,6 +15,62 @@ import (
 
 const maxLineLength = 99
 
+var additionalMethods = map[string]string{
+	"AppStatus": `
+    @property
+    def is_active(self) -> bool:
+        """Report whether the application status for this app is "active"."""
+        return self.app_status.current == 'active'
+
+    @property
+    def is_blocked(self) -> bool:
+        """Report whether the application status for this app is "blocked"."""
+        return self.app_status.current == 'blocked'
+
+    @property
+    def is_error(self) -> bool:
+        """Report whether the application status for this app is "error"."""
+        return self.app_status.current == 'error'
+
+    @property
+    def is_maintenance(self) -> bool:
+        """Report whether the application status for this app is "maintenance"."""
+        return self.app_status.current == 'maintenance'
+
+    @property
+    def is_waiting(self) -> bool:
+        """Report whether the application status for this app is "waiting"."""
+        return self.app_status.current == 'waiting'
+`,
+	"UnitStatus": `
+
+    @property
+    def is_active(self) -> bool:
+        """Report whether the workload status for this unit status is "active"."""
+        return self.workload_status.current == 'active'
+
+    @property
+    def is_blocked(self) -> bool:
+        """Report whether the workload status for this unit status is "blocked"."""
+        return self.workload_status.current == 'blocked'
+
+    @property
+    def is_error(self) -> bool:
+        """Report whether the workload status for this unit status is "error"."""
+        return self.workload_status.current == 'error'
+
+    @property
+    def is_maintenance(self) -> bool:
+        """Report whether the workload status for this unit status is "maintenance"."""
+        return self.workload_status.current == 'maintenance'
+
+    @property
+    def is_waiting(self) -> bool:
+        """Report whether the workload status for this unit status is "waiting"."""
+        return self.workload_status.current == 'waiting'
+`,
+}
+
 func main() {
 	structs := status.GetFields()
 
@@ -137,6 +193,10 @@ func main() {
 			fmt.Fprintln(&buf, line)
 		}
 		fmt.Fprintln(&buf, "        )")
+
+		if methods, ok := additionalMethods[className]; ok {
+			fmt.Fprint(&buf, methods)
+		}
 
 		classes[className] = buf.String()
 		buf.Reset()

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -13,7 +13,9 @@ import (
 	"github.com/juju/juju/cmd/juju/status"
 )
 
-// TODO: ad-hoc for struct fields
+// TODO: look closely at remaining "| None = None" fields
+// TODO: class StorageAttachments:
+//    units: dict[str, UnitStorageAttachment] # <-- should this and non-omitempty lists have defaults?
 // TODO: what exception to raise for status-error?
 //       see message in Matrix: juju-dev: https://matrix.to/#/!wJiiHsLipVywuWOyNi:ubuntu.com/$NMDdkF7koi7MrCQ6lLCKLduhk8IX3sNZlV2bGP6kuNc?via=ubuntu.com&via=matrix.org
 
@@ -24,6 +26,25 @@ func main() {
 	successors := make(map[string][]string)
 
 	structNames := slices.Sorted(maps.Keys(structs))
+
+	requireArgsStructs := make(map[string]bool)
+	for _, name := range structNames {
+		requireArgs := false
+		for _, field := range structs[name] {
+			if field.JSONField == "" {
+				continue
+			}
+			if !field.OmitEmpty {
+				requireArgs = true
+			}
+		}
+		className := strings.Title(name)
+		className = strings.ReplaceAll(className, "Application", "App")
+		if requireArgs {
+			requireArgsStructs[className] = requireArgs
+		}
+	}
+
 	for _, name := range structNames {
 		var buf bytes.Buffer
 
@@ -63,7 +84,11 @@ func main() {
 				case pythonType == "int":
 					pythonType += " = 0"
 				default:
-					pythonType += " | None = None"
+					if requireArgsStructs[pythonType] {
+						pythonType += " | None = None"
+					} else {
+						pythonType += fmt.Sprintf(" = dataclasses.field(default_factory=%s)", pythonType)
+					}
 				}
 			}
 			line := fmt.Sprintf("    %s: %s\n", pythonField, pythonType)
@@ -109,7 +134,7 @@ func main() {
 			}
 			pythonField := getPythonField(field.JSONField)
 			pythonType, _ := getPythonType(structs, field.Type)
-			dictGetter := getDictGetter(pythonType, field.JSONField, field.OmitEmpty)
+			dictGetter := getDictGetter(pythonType, field.JSONField, field.OmitEmpty, requireArgsStructs[pythonType])
 			fmt.Fprintf(&buf, "            %s=%s,\n", pythonField, dictGetter)
 		}
 		fmt.Fprintln(&buf, "        )")
@@ -180,7 +205,7 @@ func getPythonType(structs map[string][]status.FieldInfo, goType string) (string
 	}
 }
 
-func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
+func getDictGetter(pythonType string, jsonField string, omitEmpty bool, requireArgs bool) string {
 	s := fmt.Sprintf("d['%s']", jsonField)
 	orig := s
 	s = doType(pythonType, s)
@@ -199,6 +224,9 @@ func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
 			case pythonType == "int":
 				return fmt.Sprintf("d.get('%s') or 0", jsonField)
 			default:
+				if !requireArgs {
+					return fmt.Sprintf("d.get('%s') or %s()", jsonField, pythonType)
+				}
 				return fmt.Sprintf("d.get('%s')", jsonField)
 			}
 		}
@@ -214,7 +242,11 @@ func getDictGetter(pythonType string, jsonField string, omitEmpty bool) string {
 		case pythonType == "int":
 			s += fmt.Sprintf(" if '%s' in d else 0", jsonField)
 		default:
-			s += fmt.Sprintf(" if '%s' in d else None", jsonField)
+			if !requireArgs {
+				s += fmt.Sprintf(" if '%s' in d else %s()", jsonField, pythonType)
+			} else {
+				s += fmt.Sprintf(" if '%s' in d else None", jsonField)
+			}
 		}
 	}
 	return s

--- a/cmd/getfields/main.go
+++ b/cmd/getfields/main.go
@@ -159,7 +159,7 @@ func main() {
 		}
 
 		fmt.Fprintf(&buf, "\n    @classmethod\n")
-		fmt.Fprintf(&buf, "    def from_dict(cls, d: dict[str, Any]) -> %s:\n", className)
+		fmt.Fprintf(&buf, "    def _from_dict(cls, d: dict[str, Any]) -> %s:\n", className)
 
 		hasErr := false
 		for _, field := range structs[name] {
@@ -361,6 +361,6 @@ func doType(pythonType string, value string) string {
 	case pythonType == "str" || pythonType == "int" || pythonType == "bool":
 		return value
 	default:
-		return fmt.Sprintf("%s.from_dict(%s)", pythonType, value)
+		return fmt.Sprintf("%s._from_dict(%s)", pythonType, value)
 	}
 }

--- a/cmd/getfields/tarjan.go
+++ b/cmd/getfields/tarjan.go
@@ -1,0 +1,126 @@
+// This file was copied from mgo, MongoDB driver for Go.
+//
+// Copyright (c) 2010-2013 - Gustavo Niemeyer <gustavo@niemeyer.net>
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package main
+
+import (
+	"sort"
+)
+
+func tarjanSort(successors map[string][]string) [][]string {
+	// http://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+	data := &tarjanData{
+		successors: successors,
+		nodes:      make([]tarjanNode, 0, len(successors)),
+		index:      make(map[string]int, len(successors)),
+	}
+
+	// Stabilize iteration through successors map to prevent
+	// disjointed components producing unstable output due to
+	// golang map randomized iteration.
+	stableIDs := make([]string, 0, len(successors))
+	for id := range successors {
+		stableIDs = append(stableIDs, id)
+	}
+	sort.Strings(stableIDs)
+	for _, id := range stableIDs {
+		if _, seen := data.index[id]; !seen {
+			data.strongConnect(id)
+		}
+	}
+
+	// Sort connected components to stabilize the algorithm.
+	for _, ids := range data.output {
+		if len(ids) > 1 {
+			sort.Sort(idList(ids))
+		}
+	}
+	return data.output
+}
+
+type tarjanData struct {
+	successors map[string][]string
+	output     [][]string
+
+	nodes []tarjanNode
+	stack []string
+	index map[string]int
+}
+
+type tarjanNode struct {
+	lowlink int
+	stacked bool
+}
+
+type idList []string
+
+func (l idList) Len() int           { return len(l) }
+func (l idList) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l idList) Less(i, j int) bool { return l[i] < l[j] }
+
+func (data *tarjanData) strongConnect(id string) *tarjanNode {
+	index := len(data.nodes)
+	data.index[id] = index
+	data.stack = append(data.stack, id)
+	data.nodes = append(data.nodes, tarjanNode{index, true})
+	node := &data.nodes[index]
+
+	for _, succid := range data.successors[id] {
+		succindex, seen := data.index[succid]
+		if !seen {
+			succnode := data.strongConnect(succid)
+			if succnode.lowlink < node.lowlink {
+				node.lowlink = succnode.lowlink
+			}
+		} else if data.nodes[succindex].stacked {
+			// Part of the current strongly-connected component.
+			if succindex < node.lowlink {
+				node.lowlink = succindex
+			}
+		}
+	}
+
+	if node.lowlink == index {
+		// Root node; pop stack and output new
+		// strongly-connected component.
+		var scc []string
+		i := len(data.stack) - 1
+		for {
+			stackid := data.stack[i]
+			stackindex := data.index[stackid]
+			data.nodes[stackindex].stacked = false
+			scc = append(scc, stackid)
+			if stackindex == index {
+				break
+			}
+			i--
+		}
+		data.stack = data.stack[:i]
+		data.output = append(data.output, scc)
+	}
+
+	return node
+}

--- a/cmd/juju/status/getfields.go
+++ b/cmd/juju/status/getfields.go
@@ -42,18 +42,22 @@ func getFields(t reflect.Type, m map[string][]FieldInfo, typeName string, level 
 			jsonTag = field.Name
 		}
 		tagFields := strings.Split(jsonTag, ",")
-		if tagFields[0] == "-" {
-			continue
+		jsonField := tagFields[0]
+		if jsonField == "-" {
+			jsonField = ""
 		}
 		fieldType := field.Type.String()
 		niceName := getNiceName(fieldType)
 		result = append(result, FieldInfo{
 			Name:      field.Name,
 			Type:      niceName,
-			JSONField: tagFields[0],
+			JSONField: jsonField,
 			Pointer:   fieldType[0] == '*',
 			OmitEmpty: slices.Contains(tagFields[1:], "omitempty"),
 		})
+		if jsonField == "" {
+			continue
+		}
 		switch field.Type.Kind() {
 		case reflect.Struct:
 			getFields(field.Type, m, niceName, level+1)

--- a/cmd/juju/status/getfields.go
+++ b/cmd/juju/status/getfields.go
@@ -1,0 +1,93 @@
+package status
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+)
+
+func GetFields() map[string][]FieldInfo {
+	m := make(map[string][]FieldInfo)
+	getFields(reflect.TypeOf(formattedStatus{}), m, "formattedStatus", 1)
+	return m
+}
+
+func getFields(t reflect.Type, m map[string][]FieldInfo, typeName string, level int) {
+	if _, ok := m[typeName]; ok {
+		return
+	}
+
+	// Bit of a hack, but handle types like map[string][]Foo
+	switch t.Kind() {
+	case reflect.Map:
+		t = t.Elem()
+		typeName = strings.TrimPrefix(typeName, "map[string]")
+	case reflect.Slice:
+		t = t.Elem()
+		typeName = strings.TrimPrefix(typeName, "[]")
+	case reflect.Pointer:
+		t = t.Elem()
+		typeName = strings.TrimPrefix(typeName, "*")
+	}
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	m[typeName] = nil
+	var result []FieldInfo
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" {
+			jsonTag = field.Name
+		}
+		tagFields := strings.Split(jsonTag, ",")
+		if tagFields[0] == "-" {
+			continue
+		}
+		fieldType := field.Type.String()
+		niceName := getNiceName(fieldType)
+		result = append(result, FieldInfo{
+			Name:      field.Name,
+			Type:      niceName,
+			JSONField: tagFields[0],
+			Pointer:   fieldType[0] == '*',
+			OmitEmpty: slices.Contains(tagFields[1:], "omitempty"),
+		})
+		switch field.Type.Kind() {
+		case reflect.Struct:
+			getFields(field.Type, m, niceName, level+1)
+		case reflect.Map:
+			elemType := field.Type.Elem()
+			niceElemName := getNiceName(elemType.String())
+			getFields(elemType, m, niceElemName, level+1)
+		case reflect.Slice:
+			elemType := field.Type.Elem()
+			niceElemName := getNiceName(elemType.String())
+			getFields(elemType, m, niceElemName, level+1)
+		case reflect.Pointer:
+			elemType := field.Type.Elem()
+			niceElemName := getNiceName(elemType.String())
+			getFields(elemType, m, niceElemName, level+1)
+		}
+	}
+	m[typeName] = result
+}
+
+func getNiceName(s string) string {
+	if s == "instance.Id" {
+		return "string"
+	}
+	if s == "status.Status" {
+		return "string"
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(s, "status.", ""), "*", ""), "storage.", "")
+}
+
+type FieldInfo struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	JSONField string `json:"json_field"`
+	Pointer   bool   `json:"pointer"`
+	OmitEmpty bool   `json:"omit_empty"`
+}

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -32,7 +32,7 @@ type FilesystemInfo struct {
 	Storage string `yaml:"storage,omitempty" json:"storage,omitempty"`
 
 	// Attachments is the set of entities attached to the filesystem.
-	Attachments *FilesystemAttachments
+	Attachments *FilesystemAttachments `yaml:"attachments,omitempty" json:"attachments,omitempty"`
 
 	// Pool is the name of the storage pool that the filesystem came from.
 	Pool string `yaml:"pool,omitempty" json:"pool,omitempty"`

--- a/structs.py
+++ b/structs.py
@@ -5,6 +5,35 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+__all__ = [
+    'AppStatus',
+    'AppStatusRelation',
+    'CombinedStorage',
+    'ControllerStatus',
+    'EntityStatus',
+    'FilesystemAttachment',
+    'FilesystemAttachments',
+    'FilesystemInfo',
+    'FormattedBase',
+    'LxdProfileContents',
+    'MachineStatus',
+    'ModelStatus',
+    'NetworkInterface',
+    'OfferStatus',
+    'RemoteAppStatus',
+    'RemoteEndpoint',
+    'Status',
+    'StatusError',
+    'StatusInfoContents',
+    'StorageAttachments',
+    'StorageInfo',
+    'UnitStatus',
+    'UnitStorageAttachment',
+    'VolumeAttachment',
+    'VolumeAttachments',
+    'VolumeInfo',
+]
+
 
 class StatusError(Exception):
     """Raised when "juju status" returns a status-error for certain types."""

--- a/structs.py
+++ b/structs.py
@@ -706,6 +706,8 @@ class RemoteAppStatus:
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Status:
+    """Parsed version of the status object returned by "juju status --format=json"."""
+
     model: ModelStatus
     machines: dict[str, MachineStatus]
     apps: dict[str, AppStatus]

--- a/structs.py
+++ b/structs.py
@@ -67,9 +67,9 @@ class MeterStatus:
 
 @dataclasses.dataclass
 class UnitStatus:
-    workload_status: StatusInfoContents
-    juju_status: StatusInfoContents
-    meter_status: MeterStatus
+    workload_status: StatusInfoContents | None
+    juju_status: StatusInfoContents | None
+    meter_status: MeterStatus | None
     leader: bool | None
     upgrading_from: str | None
     machine: str | None
@@ -101,7 +101,7 @@ class UnitStatus:
 @dataclasses.dataclass
 class AppStatus:
     charm: str
-    base: FormattedBase
+    base: FormattedBase | None
     charm_origin: str
     charm_name: str
     charm_rev: int
@@ -114,7 +114,7 @@ class AppStatus:
     address: str | None
     exposed: bool
     life: str | None
-    app_status: StatusInfoContents
+    app_status: StatusInfoContents | None
     relations: dict[str, list[AppStatusRelation]] | None
     subordinate_to: list[str] | None
     units: dict[str, UnitStatus] | None
@@ -211,7 +211,7 @@ class StorageInfo:
     life: str | None
     status: EntityStatus
     persistent: bool
-    attachments: StorageAttachments
+    attachments: StorageAttachments | None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
@@ -263,7 +263,7 @@ class FilesystemInfo:
     pool: str | None
     size: int
     life: str | None
-    status: EntityStatus
+    status: EntityStatus | None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
@@ -317,14 +317,14 @@ class VolumeAttachments:
 class VolumeInfo:
     provider_id: str | None
     storage: str | None
-    attachments: VolumeAttachments
+    attachments: VolumeAttachments | None
     pool: str | None
     hardware_id: str | None
     wwn: str | None
     size: int
     persistent: bool
     life: str | None
-    status: EntityStatus
+    status: EntityStatus | None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
@@ -377,8 +377,8 @@ class ModelStatus:
     region: str | None
     version: str
     upgrade_available: str | None
-    model_status: StatusInfoContents
-    meter_status: MeterStatus
+    model_status: StatusInfoContents | None
+    meter_status: MeterStatus | None
     sla: str | None
 
     @classmethod
@@ -435,15 +435,15 @@ class LxdProfileContents:
 
 @dataclasses.dataclass
 class MachineStatus:
-    juju_status: StatusInfoContents
+    juju_status: StatusInfoContents | None
     hostname: str | None
     dns_name: str | None
     ip_addresses: list[str] | None
     instance_id: str | None
     display_name: str | None
-    machine_status: StatusInfoContents
-    modification_status: StatusInfoContents
-    base: FormattedBase
+    machine_status: StatusInfoContents | None
+    modification_status: StatusInfoContents | None
+    base: FormattedBase | None
     network_interfaces: dict[str, NetworkInterface] | None
     containers: dict[str, MachineStatus] | None
     constraints: str | None
@@ -492,7 +492,7 @@ class RemoteAppStatus:
     url: str
     endpoints: dict[str, RemoteEndpoint] | None
     life: str | None
-    app_status: StatusInfoContents
+    app_status: StatusInfoContents | None
     relations: dict[str, list[str]] | None
 
     @classmethod
@@ -532,8 +532,8 @@ class FormattedStatus:
     apps: dict[str, AppStatus]
     app_endpoints: dict[str, RemoteAppStatus] | None
     offers: dict[str, OfferStatus] | None
-    storage: CombinedStorage
-    controller: ControllerStatus
+    storage: CombinedStorage | None
+    controller: ControllerStatus | None
     branches: dict[str, BranchStatus] | None
 
     @classmethod

--- a/structs.py
+++ b/structs.py
@@ -55,23 +55,9 @@ class AppStatusRelation:
 
 
 @dataclasses.dataclass(frozen=True)
-class MeterStatus:
-    color: str = ''
-    message: str = ''
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> MeterStatus:
-        return cls(
-            color=d.get('color') or '',
-            message=d.get('message') or '',
-        )
-
-
-@dataclasses.dataclass(frozen=True)
 class UnitStatus:
     workload_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
     juju_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
-    meter_status: MeterStatus = dataclasses.field(default_factory=MeterStatus)
     leader: bool = False
     upgrading_from: str = ''
     machine: str = ''
@@ -80,7 +66,6 @@ class UnitStatus:
     address: str = ''
     provider_id: str = ''
     subordinates: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
-    branch: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
@@ -89,7 +74,6 @@ class UnitStatus:
         return cls(
             workload_status=StatusInfoContents.from_dict(d['workload-status']) if 'workload-status' in d else StatusInfoContents(),
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else StatusInfoContents(),
-            meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else MeterStatus(),
             leader=d.get('leader') or False,
             upgrading_from=d.get('upgrading-from') or '',
             machine=d.get('machine') or '',
@@ -98,7 +82,6 @@ class UnitStatus:
             address=d.get('address') or '',
             provider_id=d.get('provider-id') or '',
             subordinates={k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()} if 'subordinates' in d else {},
-            branch=d.get('branch') or '',
         )
 
 
@@ -151,23 +134,6 @@ class AppStatus:
             units={k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
             version=d.get('version') or '',
             endpoint_bindings=d.get('endpoint-bindings') or {},
-        )
-
-
-@dataclasses.dataclass(frozen=True)
-class BranchStatus:
-    ref: str = ''
-    created: str = ''
-    created_by: str = ''
-    active: bool = False
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> BranchStatus:
-        return cls(
-            ref=d.get('ref') or '',
-            created=d.get('created') or '',
-            created_by=d.get('created-by') or '',
-            active=d.get('active') or False,
         )
 
 
@@ -391,8 +357,6 @@ class ModelStatus:
     region: str = ''
     upgrade_available: str = ''
     model_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
-    meter_status: MeterStatus = dataclasses.field(default_factory=MeterStatus)
-    sla: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
@@ -405,8 +369,6 @@ class ModelStatus:
             version=d['version'],
             upgrade_available=d.get('upgrade-available') or '',
             model_status=StatusInfoContents.from_dict(d['model-status']) if 'model-status' in d else StatusInfoContents(),
-            meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else MeterStatus(),
-            sla=d.get('sla') or '',
         )
 
 
@@ -557,7 +519,6 @@ class FormattedStatus:
     offers: dict[str, OfferStatus] = dataclasses.field(default_factory=dict)
     storage: CombinedStorage = dataclasses.field(default_factory=CombinedStorage)
     controller: ControllerStatus = dataclasses.field(default_factory=ControllerStatus)
-    branches: dict[str, BranchStatus] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FormattedStatus:
@@ -569,5 +530,4 @@ class FormattedStatus:
             offers={k: OfferStatus.from_dict(v) for k, v in d['offers'].items()} if 'offers' in d else {},
             storage=CombinedStorage.from_dict(d['storage']) if 'storage' in d else CombinedStorage(),
             controller=ControllerStatus.from_dict(d['controller']) if 'controller' in d else ControllerStatus(),
-            branches={k: BranchStatus.from_dict(v) for k, v in d['branches'].items()} if 'branches' in d else {},
         )

--- a/structs.py
+++ b/structs.py
@@ -1,6 +1,7 @@
 """Dataclasses used to hold parsed output from "juju status --format=json"."""
 
 from __future__ import annotations
+
 import dataclasses
 from typing import Any
 
@@ -102,6 +103,31 @@ class UnitStatus:
             ),
         )
 
+    @property
+    def is_active(self) -> bool:
+        """Report whether the workload status for this unit status is "active"."""
+        return self.workload_status.current == 'active'
+
+    @property
+    def is_blocked(self) -> bool:
+        """Report whether the workload status for this unit status is "blocked"."""
+        return self.workload_status.current == 'blocked'
+
+    @property
+    def is_error(self) -> bool:
+        """Report whether the workload status for this unit status is "error"."""
+        return self.workload_status.current == 'error'
+
+    @property
+    def is_maintenance(self) -> bool:
+        """Report whether the workload status for this unit status is "maintenance"."""
+        return self.workload_status.current == 'maintenance'
+
+    @property
+    def is_waiting(self) -> bool:
+        """Report whether the workload status for this unit status is "waiting"."""
+        return self.workload_status.current == 'waiting'
+
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class AppStatus:
@@ -163,6 +189,31 @@ class AppStatus:
             version=d.get('version') or '',
             endpoint_bindings=d.get('endpoint-bindings') or {},
         )
+
+    @property
+    def is_active(self) -> bool:
+        """Report whether the application status for this app is "active"."""
+        return self.app_status.current == 'active'
+
+    @property
+    def is_blocked(self) -> bool:
+        """Report whether the application status for this app is "blocked"."""
+        return self.app_status.current == 'blocked'
+
+    @property
+    def is_error(self) -> bool:
+        """Report whether the application status for this app is "error"."""
+        return self.app_status.current == 'error'
+
+    @property
+    def is_maintenance(self) -> bool:
+        """Report whether the application status for this app is "maintenance"."""
+        return self.app_status.current == 'maintenance'
+
+    @property
+    def is_waiting(self) -> bool:
+        """Report whether the application status for this app is "waiting"."""
+        return self.app_status.current == 'waiting'
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/structs.py
+++ b/structs.py
@@ -18,12 +18,12 @@ class FormattedBase:
 
 @dataclasses.dataclass
 class StatusInfoContents:
-    current: str | None
-    message: str | None
-    reason: str | None
-    since: str | None
-    version: str | None
-    life: str | None
+    current: str | None = None
+    message: str | None = None
+    reason: str | None = None
+    since: str | None = None
+    version: str | None = None
+    life: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
@@ -39,9 +39,9 @@ class StatusInfoContents:
 
 @dataclasses.dataclass
 class AppStatusRelation:
-    related_app: str | None
-    interface: str | None
-    scope: str | None
+    related_app: str | None = None
+    interface: str | None = None
+    scope: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
@@ -54,8 +54,8 @@ class AppStatusRelation:
 
 @dataclasses.dataclass
 class MeterStatus:
-    color: str | None
-    message: str | None
+    color: str | None = None
+    message: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> MeterStatus:
@@ -67,18 +67,18 @@ class MeterStatus:
 
 @dataclasses.dataclass
 class UnitStatus:
-    workload_status: StatusInfoContents | None
-    juju_status: StatusInfoContents | None
-    meter_status: MeterStatus | None
-    leader: bool | None
-    upgrading_from: str | None
-    machine: str | None
-    open_ports: list[str] | None
-    public_address: str | None
-    address: str | None
-    provider_id: str | None
-    subordinates: dict[str, UnitStatus] | None
-    branch: str | None
+    workload_status: StatusInfoContents | None = None
+    juju_status: StatusInfoContents | None = None
+    meter_status: MeterStatus | None = None
+    leader: bool | None = None
+    upgrading_from: str | None = None
+    machine: str | None = None
+    open_ports: list[str] | None = None
+    public_address: str | None = None
+    address: str | None = None
+    provider_id: str | None = None
+    subordinates: dict[str, UnitStatus] | None = None
+    branch: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
@@ -101,25 +101,26 @@ class UnitStatus:
 @dataclasses.dataclass
 class AppStatus:
     charm: str
-    base: FormattedBase | None
     charm_origin: str
     charm_name: str
     charm_rev: int
-    charm_channel: str | None
-    charm_version: str | None
-    charm_profile: str | None
-    can_upgrade_to: str | None
-    scale: int | None
-    provider_id: str | None
-    address: str | None
     exposed: bool
-    life: str | None
-    app_status: StatusInfoContents | None
-    relations: dict[str, list[AppStatusRelation]] | None
-    subordinate_to: list[str] | None
-    units: dict[str, UnitStatus] | None
-    version: str | None
-    endpoint_bindings: dict[str, str] | None
+
+    base: FormattedBase | None = None
+    charm_channel: str | None = None
+    charm_version: str | None = None
+    charm_profile: str | None = None
+    can_upgrade_to: str | None = None
+    scale: int | None = None
+    provider_id: str | None = None
+    address: str | None = None
+    life: str | None = None
+    app_status: StatusInfoContents | None = None
+    relations: dict[str, list[AppStatusRelation]] | None = None
+    subordinate_to: list[str] | None = None
+    units: dict[str, UnitStatus] | None = None
+    version: str | None = None
+    endpoint_bindings: dict[str, str] | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> AppStatus:
@@ -149,10 +150,10 @@ class AppStatus:
 
 @dataclasses.dataclass
 class BranchStatus:
-    ref: str | None
-    created: str | None
-    created_by: str | None
-    active: bool | None
+    ref: str | None = None
+    created: str | None = None
+    created_by: str | None = None
+    active: bool | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> BranchStatus:
@@ -166,9 +167,9 @@ class BranchStatus:
 
 @dataclasses.dataclass
 class EntityStatus:
-    current: str | None
-    message: str | None
-    since: str | None
+    current: str | None = None
+    message: str | None = None
+    since: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> EntityStatus:
@@ -181,9 +182,9 @@ class EntityStatus:
 
 @dataclasses.dataclass
 class UnitStorageAttachment:
-    machine: str | None
-    location: str | None
-    life: str | None
+    machine: str | None = None
+    location: str | None = None
+    life: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> UnitStorageAttachment:
@@ -208,10 +209,11 @@ class StorageAttachments:
 @dataclasses.dataclass
 class StorageInfo:
     kind: str
-    life: str | None
     status: EntityStatus
     persistent: bool
-    attachments: StorageAttachments | None
+
+    life: str | None = None
+    attachments: StorageAttachments | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
@@ -228,7 +230,8 @@ class StorageInfo:
 class FilesystemAttachment:
     mount_point: str
     read_only: bool
-    life: str | None
+
+    life: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachment:
@@ -241,9 +244,9 @@ class FilesystemAttachment:
 
 @dataclasses.dataclass
 class FilesystemAttachments:
-    machines: dict[str, FilesystemAttachment] | None
-    containers: dict[str, FilesystemAttachment] | None
-    units: dict[str, UnitStorageAttachment] | None
+    machines: dict[str, FilesystemAttachment] | None = None
+    containers: dict[str, FilesystemAttachment] | None = None
+    units: dict[str, UnitStorageAttachment] | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
@@ -256,14 +259,15 @@ class FilesystemAttachments:
 
 @dataclasses.dataclass
 class FilesystemInfo:
-    provider_id: str | None
-    volume: str | None
-    storage: str | None
     Attachments: FilesystemAttachments
-    pool: str | None
     size: int
-    life: str | None
-    status: EntityStatus | None
+
+    provider_id: str | None = None
+    volume: str | None = None
+    storage: str | None = None
+    pool: str | None = None
+    life: str | None = None
+    status: EntityStatus | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
@@ -281,11 +285,12 @@ class FilesystemInfo:
 
 @dataclasses.dataclass
 class VolumeAttachment:
-    device: str | None
-    device_link: str | None
-    bus_address: str | None
     read_only: bool
-    life: str | None
+
+    device: str | None = None
+    device_link: str | None = None
+    bus_address: str | None = None
+    life: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
@@ -300,9 +305,9 @@ class VolumeAttachment:
 
 @dataclasses.dataclass
 class VolumeAttachments:
-    machines: dict[str, VolumeAttachment] | None
-    containers: dict[str, VolumeAttachment] | None
-    units: dict[str, UnitStorageAttachment] | None
+    machines: dict[str, VolumeAttachment] | None = None
+    containers: dict[str, VolumeAttachment] | None = None
+    units: dict[str, UnitStorageAttachment] | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
@@ -315,16 +320,17 @@ class VolumeAttachments:
 
 @dataclasses.dataclass
 class VolumeInfo:
-    provider_id: str | None
-    storage: str | None
-    attachments: VolumeAttachments | None
-    pool: str | None
-    hardware_id: str | None
-    wwn: str | None
     size: int
     persistent: bool
-    life: str | None
-    status: EntityStatus | None
+
+    provider_id: str | None = None
+    storage: str | None = None
+    attachments: VolumeAttachments | None = None
+    pool: str | None = None
+    hardware_id: str | None = None
+    wwn: str | None = None
+    life: str | None = None
+    status: EntityStatus | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
@@ -344,9 +350,9 @@ class VolumeInfo:
 
 @dataclasses.dataclass
 class CombinedStorage:
-    storage: dict[str, StorageInfo] | None
-    filesystems: dict[str, FilesystemInfo] | None
-    volumes: dict[str, VolumeInfo] | None
+    storage: dict[str, StorageInfo] | None = None
+    filesystems: dict[str, FilesystemInfo] | None = None
+    volumes: dict[str, VolumeInfo] | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
@@ -359,7 +365,7 @@ class CombinedStorage:
 
 @dataclasses.dataclass
 class ControllerStatus:
-    timestamp: str | None
+    timestamp: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> ControllerStatus:
@@ -374,12 +380,13 @@ class ModelStatus:
     type: str
     controller: str
     cloud: str
-    region: str | None
     version: str
-    upgrade_available: str | None
-    model_status: StatusInfoContents | None
-    meter_status: MeterStatus | None
-    sla: str | None
+
+    region: str | None = None
+    upgrade_available: str | None = None
+    model_status: StatusInfoContents | None = None
+    meter_status: MeterStatus | None = None
+    sla: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
@@ -401,10 +408,11 @@ class ModelStatus:
 class NetworkInterface:
     ip_addresses: list[str]
     mac_address: str
-    gateway: str | None
-    dns_nameservers: list[str] | None
-    space: str | None
     is_up: bool
+
+    gateway: str | None = None
+    dns_nameservers: list[str] | None = None
+    space: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
@@ -435,22 +443,22 @@ class LxdProfileContents:
 
 @dataclasses.dataclass
 class MachineStatus:
-    juju_status: StatusInfoContents | None
-    hostname: str | None
-    dns_name: str | None
-    ip_addresses: list[str] | None
-    instance_id: str | None
-    display_name: str | None
-    machine_status: StatusInfoContents | None
-    modification_status: StatusInfoContents | None
-    base: FormattedBase | None
-    network_interfaces: dict[str, NetworkInterface] | None
-    containers: dict[str, MachineStatus] | None
-    constraints: str | None
-    hardware: str | None
-    controller_member_status: str | None
-    ha_primary: bool | None
-    lxd_profiles: dict[str, LxdProfileContents] | None
+    juju_status: StatusInfoContents | None = None
+    hostname: str | None = None
+    dns_name: str | None = None
+    ip_addresses: list[str] | None = None
+    instance_id: str | None = None
+    display_name: str | None = None
+    machine_status: StatusInfoContents | None = None
+    modification_status: StatusInfoContents | None = None
+    base: FormattedBase | None = None
+    network_interfaces: dict[str, NetworkInterface] | None = None
+    containers: dict[str, MachineStatus] | None = None
+    constraints: str | None = None
+    hardware: str | None = None
+    controller_member_status: str | None = None
+    ha_primary: bool | None = None
+    lxd_profiles: dict[str, LxdProfileContents] | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> MachineStatus:
@@ -490,10 +498,11 @@ class RemoteEndpoint:
 @dataclasses.dataclass
 class RemoteAppStatus:
     url: str
-    endpoints: dict[str, RemoteEndpoint] | None
-    life: str | None
-    app_status: StatusInfoContents | None
-    relations: dict[str, list[str]] | None
+
+    endpoints: dict[str, RemoteEndpoint] | None = None
+    life: str | None = None
+    app_status: StatusInfoContents | None = None
+    relations: dict[str, list[str]] | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
@@ -509,10 +518,11 @@ class RemoteAppStatus:
 @dataclasses.dataclass
 class OfferStatus:
     app: str
-    charm: str | None
-    total_connected_count: int | None
-    active_connected_count: int | None
     endpoints: dict[str, RemoteEndpoint]
+
+    charm: str | None = None
+    total_connected_count: int | None = None
+    active_connected_count: int | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
@@ -530,11 +540,12 @@ class FormattedStatus:
     model: ModelStatus
     machines: dict[str, MachineStatus]
     apps: dict[str, AppStatus]
-    app_endpoints: dict[str, RemoteAppStatus] | None
-    offers: dict[str, OfferStatus] | None
-    storage: CombinedStorage | None
-    controller: ControllerStatus | None
-    branches: dict[str, BranchStatus] | None
+
+    app_endpoints: dict[str, RemoteAppStatus] | None = None
+    offers: dict[str, OfferStatus] | None = None
+    storage: CombinedStorage | None = None
+    controller: ControllerStatus | None = None
+    branches: dict[str, BranchStatus] | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FormattedStatus:

--- a/structs.py
+++ b/structs.py
@@ -73,11 +73,11 @@ class UnitStatus:
     leader: bool | None = None
     upgrading_from: str | None = None
     machine: str | None = None
-    open_ports: list[str] | None = None
+    open_ports: list[str] = dataclasses.field(default_factory=list)
     public_address: str | None = None
     address: str | None = None
     provider_id: str | None = None
-    subordinates: dict[str, UnitStatus] | None = None
+    subordinates: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
     branch: str | None = None
 
     @classmethod
@@ -89,11 +89,11 @@ class UnitStatus:
             leader=d.get('leader'),
             upgrading_from=d.get('upgrading-from'),
             machine=d.get('machine'),
-            open_ports=d.get('open-ports'),
+            open_ports=d.get('open-ports') or [],
             public_address=d.get('public-address'),
             address=d.get('address'),
             provider_id=d.get('provider-id'),
-            subordinates={k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()} if 'subordinates' in d else None,
+            subordinates={k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()} if 'subordinates' in d else {},
             branch=d.get('branch'),
         )
 
@@ -116,11 +116,11 @@ class AppStatus:
     address: str | None = None
     life: str | None = None
     app_status: StatusInfoContents | None = None
-    relations: dict[str, list[AppStatusRelation]] | None = None
-    subordinate_to: list[str] | None = None
-    units: dict[str, UnitStatus] | None = None
+    relations: dict[str, list[AppStatusRelation]] = dataclasses.field(default_factory=dict)
+    subordinate_to: list[str] = dataclasses.field(default_factory=list)
+    units: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
     version: str | None = None
-    endpoint_bindings: dict[str, str] | None = None
+    endpoint_bindings: dict[str, str] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> AppStatus:
@@ -140,11 +140,11 @@ class AppStatus:
             exposed=d['exposed'],
             life=d.get('life'),
             app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
-            relations={k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()} if 'relations' in d else None,
-            subordinate_to=d.get('subordinate-to'),
-            units={k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else None,
+            relations={k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()} if 'relations' in d else {},
+            subordinate_to=d.get('subordinate-to') or [],
+            units={k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
             version=d.get('version'),
-            endpoint_bindings=d.get('endpoint-bindings'),
+            endpoint_bindings=d.get('endpoint-bindings') or {},
         )
 
 
@@ -244,16 +244,16 @@ class FilesystemAttachment:
 
 @dataclasses.dataclass
 class FilesystemAttachments:
-    machines: dict[str, FilesystemAttachment] | None = None
-    containers: dict[str, FilesystemAttachment] | None = None
-    units: dict[str, UnitStorageAttachment] | None = None
+    machines: dict[str, FilesystemAttachment] = dataclasses.field(default_factory=dict)
+    containers: dict[str, FilesystemAttachment] = dataclasses.field(default_factory=dict)
+    units: dict[str, UnitStorageAttachment] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
         return cls(
-            machines={k: FilesystemAttachment.from_dict(v) for k, v in d['machines'].items()} if 'machines' in d else None,
-            containers={k: FilesystemAttachment.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else None,
-            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()} if 'units' in d else None,
+            machines={k: FilesystemAttachment.from_dict(v) for k, v in d['machines'].items()} if 'machines' in d else {},
+            containers={k: FilesystemAttachment.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else {},
+            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
         )
 
 
@@ -305,16 +305,16 @@ class VolumeAttachment:
 
 @dataclasses.dataclass
 class VolumeAttachments:
-    machines: dict[str, VolumeAttachment] | None = None
-    containers: dict[str, VolumeAttachment] | None = None
-    units: dict[str, UnitStorageAttachment] | None = None
+    machines: dict[str, VolumeAttachment] = dataclasses.field(default_factory=dict)
+    containers: dict[str, VolumeAttachment] = dataclasses.field(default_factory=dict)
+    units: dict[str, UnitStorageAttachment] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
         return cls(
-            machines={k: VolumeAttachment.from_dict(v) for k, v in d['machines'].items()} if 'machines' in d else None,
-            containers={k: VolumeAttachment.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else None,
-            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()} if 'units' in d else None,
+            machines={k: VolumeAttachment.from_dict(v) for k, v in d['machines'].items()} if 'machines' in d else {},
+            containers={k: VolumeAttachment.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else {},
+            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
         )
 
 
@@ -350,16 +350,16 @@ class VolumeInfo:
 
 @dataclasses.dataclass
 class CombinedStorage:
-    storage: dict[str, StorageInfo] | None = None
-    filesystems: dict[str, FilesystemInfo] | None = None
-    volumes: dict[str, VolumeInfo] | None = None
+    storage: dict[str, StorageInfo] = dataclasses.field(default_factory=dict)
+    filesystems: dict[str, FilesystemInfo] = dataclasses.field(default_factory=dict)
+    volumes: dict[str, VolumeInfo] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
         return cls(
-            storage={k: StorageInfo.from_dict(v) for k, v in d['storage'].items()} if 'storage' in d else None,
-            filesystems={k: FilesystemInfo.from_dict(v) for k, v in d['filesystems'].items()} if 'filesystems' in d else None,
-            volumes={k: VolumeInfo.from_dict(v) for k, v in d['volumes'].items()} if 'volumes' in d else None,
+            storage={k: StorageInfo.from_dict(v) for k, v in d['storage'].items()} if 'storage' in d else {},
+            filesystems={k: FilesystemInfo.from_dict(v) for k, v in d['filesystems'].items()} if 'filesystems' in d else {},
+            volumes={k: VolumeInfo.from_dict(v) for k, v in d['volumes'].items()} if 'volumes' in d else {},
         )
 
 
@@ -411,7 +411,7 @@ class NetworkInterface:
     is_up: bool
 
     gateway: str | None = None
-    dns_nameservers: list[str] | None = None
+    dns_nameservers: list[str] = dataclasses.field(default_factory=list)
     space: str | None = None
 
     @classmethod
@@ -420,7 +420,7 @@ class NetworkInterface:
             ip_addresses=d['ip-addresses'],
             mac_address=d['mac-address'],
             gateway=d.get('gateway'),
-            dns_nameservers=d.get('dns-nameservers'),
+            dns_nameservers=d.get('dns-nameservers') or [],
             space=d.get('space'),
             is_up=d['is-up'],
         )
@@ -446,19 +446,19 @@ class MachineStatus:
     juju_status: StatusInfoContents | None = None
     hostname: str | None = None
     dns_name: str | None = None
-    ip_addresses: list[str] | None = None
+    ip_addresses: list[str] = dataclasses.field(default_factory=list)
     instance_id: str | None = None
     display_name: str | None = None
     machine_status: StatusInfoContents | None = None
     modification_status: StatusInfoContents | None = None
     base: FormattedBase | None = None
-    network_interfaces: dict[str, NetworkInterface] | None = None
-    containers: dict[str, MachineStatus] | None = None
+    network_interfaces: dict[str, NetworkInterface] = dataclasses.field(default_factory=dict)
+    containers: dict[str, MachineStatus] = dataclasses.field(default_factory=dict)
     constraints: str | None = None
     hardware: str | None = None
     controller_member_status: str | None = None
     ha_primary: bool | None = None
-    lxd_profiles: dict[str, LxdProfileContents] | None = None
+    lxd_profiles: dict[str, LxdProfileContents] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> MachineStatus:
@@ -466,19 +466,19 @@ class MachineStatus:
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
             hostname=d.get('hostname'),
             dns_name=d.get('dns-name'),
-            ip_addresses=d.get('ip-addresses'),
+            ip_addresses=d.get('ip-addresses') or [],
             instance_id=d.get('instance-id'),
             display_name=d.get('display-name'),
             machine_status=StatusInfoContents.from_dict(d['machine-status']) if 'machine-status' in d else None,
             modification_status=StatusInfoContents.from_dict(d['modification-status']) if 'modification-status' in d else None,
             base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
-            network_interfaces={k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()} if 'network-interfaces' in d else None,
-            containers={k: MachineStatus.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else None,
+            network_interfaces={k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()} if 'network-interfaces' in d else {},
+            containers={k: MachineStatus.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else {},
             constraints=d.get('constraints'),
             hardware=d.get('hardware'),
             controller_member_status=d.get('controller-member-status'),
             ha_primary=d.get('ha-primary'),
-            lxd_profiles={k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()} if 'lxd-profiles' in d else None,
+            lxd_profiles={k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()} if 'lxd-profiles' in d else {},
         )
 
 
@@ -499,19 +499,19 @@ class RemoteEndpoint:
 class RemoteAppStatus:
     url: str
 
-    endpoints: dict[str, RemoteEndpoint] | None = None
+    endpoints: dict[str, RemoteEndpoint] = dataclasses.field(default_factory=dict)
     life: str | None = None
     app_status: StatusInfoContents | None = None
-    relations: dict[str, list[str]] | None = None
+    relations: dict[str, list[str]] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
         return cls(
             url=d['url'],
-            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else None,
+            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else {},
             life=d.get('life'),
             app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
-            relations=d.get('relations'),
+            relations=d.get('relations') or {},
         )
 
 
@@ -541,11 +541,11 @@ class FormattedStatus:
     machines: dict[str, MachineStatus]
     apps: dict[str, AppStatus]
 
-    app_endpoints: dict[str, RemoteAppStatus] | None = None
-    offers: dict[str, OfferStatus] | None = None
+    app_endpoints: dict[str, RemoteAppStatus] = dataclasses.field(default_factory=dict)
+    offers: dict[str, OfferStatus] = dataclasses.field(default_factory=dict)
     storage: CombinedStorage | None = None
     controller: ControllerStatus | None = None
-    branches: dict[str, BranchStatus] | None = None
+    branches: dict[str, BranchStatus] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FormattedStatus:
@@ -553,9 +553,9 @@ class FormattedStatus:
             model=ModelStatus.from_dict(d['model']),
             machines={k: MachineStatus.from_dict(v) for k, v in d['machines'].items()},
             apps={k: AppStatus.from_dict(v) for k, v in d['applications'].items()},
-            app_endpoints={k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()} if 'application-endpoints' in d else None,
-            offers={k: OfferStatus.from_dict(v) for k, v in d['offers'].items()} if 'offers' in d else None,
+            app_endpoints={k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()} if 'application-endpoints' in d else {},
+            offers={k: OfferStatus.from_dict(v) for k, v in d['offers'].items()} if 'offers' in d else {},
             storage=CombinedStorage.from_dict(d['storage']) if 'storage' in d else None,
             controller=ControllerStatus.from_dict(d['controller']) if 'controller' in d else None,
-            branches={k: BranchStatus.from_dict(v) for k, v in d['branches'].items()} if 'branches' in d else None,
+            branches={k: BranchStatus.from_dict(v) for k, v in d['branches'].items()} if 'branches' in d else {},
         )

--- a/structs.py
+++ b/structs.py
@@ -78,8 +78,16 @@ class UnitStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
-            workload_status=StatusInfoContents.from_dict(d['workload-status']) if 'workload-status' in d else StatusInfoContents(),
-            juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else StatusInfoContents(),
+            workload_status=(
+                StatusInfoContents.from_dict(d['workload-status'])
+                if 'workload-status' in d
+                else StatusInfoContents()
+            ),
+            juju_status=(
+                StatusInfoContents.from_dict(d['juju-status'])
+                if 'juju-status' in d
+                else StatusInfoContents()
+            ),
             leader=d.get('leader') or False,
             upgrading_from=d.get('upgrading-from') or '',
             machine=d.get('machine') or '',
@@ -87,7 +95,11 @@ class UnitStatus:
             public_address=d.get('public-address') or '',
             address=d.get('address') or '',
             provider_id=d.get('provider-id') or '',
-            subordinates={k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()} if 'subordinates' in d else {},
+            subordinates=(
+                {k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()}
+                if 'subordinates' in d
+                else {}
+            ),
         )
 
 
@@ -134,10 +146,20 @@ class AppStatus:
             address=d.get('address') or '',
             exposed=d['exposed'],
             life=d.get('life') or '',
-            app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else StatusInfoContents(),
-            relations={k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()} if 'relations' in d else {},
+            app_status=(
+                StatusInfoContents.from_dict(d['application-status'])
+                if 'application-status' in d
+                else StatusInfoContents()
+            ),
+            relations=(
+                {k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()}
+                if 'relations' in d
+                else {}
+            ),
             subordinate_to=d.get('subordinate-to') or [],
-            units={k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
+            units=(
+                {k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {}
+            ),
             version=d.get('version') or '',
             endpoint_bindings=d.get('endpoint-bindings') or {},
         )
@@ -200,7 +222,9 @@ class StorageInfo:
             life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']),
             persistent=d['persistent'],
-            attachments=StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None,
+            attachments=(
+                StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None
+            ),
         )
 
 
@@ -229,9 +253,21 @@ class FilesystemAttachments:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
         return cls(
-            machines={k: FilesystemAttachment.from_dict(v) for k, v in d['machines'].items()} if 'machines' in d else {},
-            containers={k: FilesystemAttachment.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else {},
-            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
+            machines=(
+                {k: FilesystemAttachment.from_dict(v) for k, v in d['machines'].items()}
+                if 'machines' in d
+                else {}
+            ),
+            containers=(
+                {k: FilesystemAttachment.from_dict(v) for k, v in d['containers'].items()}
+                if 'containers' in d
+                else {}
+            ),
+            units=(
+                {k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()}
+                if 'units' in d
+                else {}
+            ),
         )
 
 
@@ -290,9 +326,21 @@ class VolumeAttachments:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
         return cls(
-            machines={k: VolumeAttachment.from_dict(v) for k, v in d['machines'].items()} if 'machines' in d else {},
-            containers={k: VolumeAttachment.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else {},
-            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
+            machines=(
+                {k: VolumeAttachment.from_dict(v) for k, v in d['machines'].items()}
+                if 'machines' in d
+                else {}
+            ),
+            containers=(
+                {k: VolumeAttachment.from_dict(v) for k, v in d['containers'].items()}
+                if 'containers' in d
+                else {}
+            ),
+            units=(
+                {k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()}
+                if 'units' in d
+                else {}
+            ),
         )
 
 
@@ -315,7 +363,11 @@ class VolumeInfo:
         return cls(
             provider_id=d.get('provider-id') or '',
             storage=d.get('storage') or '',
-            attachments=VolumeAttachments.from_dict(d['attachments']) if 'attachments' in d else VolumeAttachments(),
+            attachments=(
+                VolumeAttachments.from_dict(d['attachments'])
+                if 'attachments' in d
+                else VolumeAttachments()
+            ),
             pool=d.get('pool') or '',
             hardware_id=d.get('hardware-id') or '',
             wwn=d.get('wwn') or '',
@@ -335,9 +387,21 @@ class CombinedStorage:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
         return cls(
-            storage={k: StorageInfo.from_dict(v) for k, v in d['storage'].items()} if 'storage' in d else {},
-            filesystems={k: FilesystemInfo.from_dict(v) for k, v in d['filesystems'].items()} if 'filesystems' in d else {},
-            volumes={k: VolumeInfo.from_dict(v) for k, v in d['volumes'].items()} if 'volumes' in d else {},
+            storage=(
+                {k: StorageInfo.from_dict(v) for k, v in d['storage'].items()}
+                if 'storage' in d
+                else {}
+            ),
+            filesystems=(
+                {k: FilesystemInfo.from_dict(v) for k, v in d['filesystems'].items()}
+                if 'filesystems' in d
+                else {}
+            ),
+            volumes=(
+                {k: VolumeInfo.from_dict(v) for k, v in d['volumes'].items()}
+                if 'volumes' in d
+                else {}
+            ),
         )
 
 
@@ -374,7 +438,11 @@ class ModelStatus:
             region=d.get('region') or '',
             version=d['version'],
             upgrade_available=d.get('upgrade-available') or '',
-            model_status=StatusInfoContents.from_dict(d['model-status']) if 'model-status' in d else StatusInfoContents(),
+            model_status=(
+                StatusInfoContents.from_dict(d['model-status'])
+                if 'model-status' in d
+                else StatusInfoContents()
+            ),
         )
 
 
@@ -439,22 +507,46 @@ class MachineStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
-            juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else StatusInfoContents(),
+            juju_status=(
+                StatusInfoContents.from_dict(d['juju-status'])
+                if 'juju-status' in d
+                else StatusInfoContents()
+            ),
             hostname=d.get('hostname') or '',
             dns_name=d.get('dns-name') or '',
             ip_addresses=d.get('ip-addresses') or [],
             instance_id=d.get('instance-id') or '',
             display_name=d.get('display-name') or '',
-            machine_status=StatusInfoContents.from_dict(d['machine-status']) if 'machine-status' in d else StatusInfoContents(),
-            modification_status=StatusInfoContents.from_dict(d['modification-status']) if 'modification-status' in d else StatusInfoContents(),
+            machine_status=(
+                StatusInfoContents.from_dict(d['machine-status'])
+                if 'machine-status' in d
+                else StatusInfoContents()
+            ),
+            modification_status=(
+                StatusInfoContents.from_dict(d['modification-status'])
+                if 'modification-status' in d
+                else StatusInfoContents()
+            ),
             base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
-            network_interfaces={k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()} if 'network-interfaces' in d else {},
-            containers={k: MachineStatus.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else {},
+            network_interfaces=(
+                {k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()}
+                if 'network-interfaces' in d
+                else {}
+            ),
+            containers=(
+                {k: MachineStatus.from_dict(v) for k, v in d['containers'].items()}
+                if 'containers' in d
+                else {}
+            ),
             constraints=d.get('constraints') or '',
             hardware=d.get('hardware') or '',
             controller_member_status=d.get('controller-member-status') or '',
             ha_primary=d.get('ha-primary') or False,
-            lxd_profiles={k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()} if 'lxd-profiles' in d else {},
+            lxd_profiles=(
+                {k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()}
+                if 'lxd-profiles' in d
+                else {}
+            ),
         )
 
 
@@ -486,9 +578,17 @@ class RemoteAppStatus:
             raise StatusError(d['status-error'])
         return cls(
             url=d['url'],
-            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else {},
+            endpoints=(
+                {k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()}
+                if 'endpoints' in d
+                else {}
+            ),
             life=d.get('life') or '',
-            app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else StatusInfoContents(),
+            app_status=(
+                StatusInfoContents.from_dict(d['application-status'])
+                if 'application-status' in d
+                else StatusInfoContents()
+            ),
             relations=d.get('relations') or {},
         )
 
@@ -532,8 +632,22 @@ class FormattedStatus:
             model=ModelStatus.from_dict(d['model']),
             machines={k: MachineStatus.from_dict(v) for k, v in d['machines'].items()},
             apps={k: AppStatus.from_dict(v) for k, v in d['applications'].items()},
-            app_endpoints={k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()} if 'application-endpoints' in d else {},
-            offers={k: OfferStatus.from_dict(v) for k, v in d['offers'].items()} if 'offers' in d else {},
-            storage=CombinedStorage.from_dict(d['storage']) if 'storage' in d else CombinedStorage(),
-            controller=ControllerStatus.from_dict(d['controller']) if 'controller' in d else ControllerStatus(),
+            app_endpoints=(
+                {k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()}
+                if 'application-endpoints' in d
+                else {}
+            ),
+            offers=(
+                {k: OfferStatus.from_dict(v) for k, v in d['offers'].items()}
+                if 'offers' in d
+                else {}
+            ),
+            storage=(
+                CombinedStorage.from_dict(d['storage']) if 'storage' in d else CombinedStorage()
+            ),
+            controller=(
+                ControllerStatus.from_dict(d['controller'])
+                if 'controller' in d
+                else ControllerStatus()
+            ),
         )

--- a/structs.py
+++ b/structs.py
@@ -16,7 +16,7 @@ class FormattedBase:
     channel: str
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FormattedBase:
+    def _from_dict(cls, d: dict[str, Any]) -> FormattedBase:
         return cls(
             name=d['name'],
             channel=d['channel'],
@@ -33,7 +33,7 @@ class StatusInfoContents:
     life: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
+    def _from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
@@ -53,7 +53,7 @@ class AppStatusRelation:
     scope: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
+    def _from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
         return cls(
             related_app=d.get('related-application') or '',
             interface=d.get('interface') or '',
@@ -75,17 +75,17 @@ class UnitStatus:
     subordinates: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> UnitStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
             workload_status=(
-                StatusInfoContents.from_dict(d['workload-status'])
+                StatusInfoContents._from_dict(d['workload-status'])
                 if 'workload-status' in d
                 else StatusInfoContents()
             ),
             juju_status=(
-                StatusInfoContents.from_dict(d['juju-status'])
+                StatusInfoContents._from_dict(d['juju-status'])
                 if 'juju-status' in d
                 else StatusInfoContents()
             ),
@@ -97,7 +97,7 @@ class UnitStatus:
             address=d.get('address') or '',
             provider_id=d.get('provider-id') or '',
             subordinates=(
-                {k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()}
+                {k: UnitStatus._from_dict(v) for k, v in d['subordinates'].items()}
                 if 'subordinates' in d
                 else {}
             ),
@@ -154,7 +154,7 @@ class AppStatus:
     endpoint_bindings: dict[str, str] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> AppStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> AppStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
@@ -163,7 +163,7 @@ class AppStatus:
             charm_name=d['charm-name'],
             charm_rev=d['charm-rev'],
             exposed=d['exposed'],
-            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
+            base=FormattedBase._from_dict(d['base']) if 'base' in d else None,
             charm_channel=d.get('charm-channel') or '',
             charm_version=d.get('charm-version') or '',
             charm_profile=d.get('charm-profile') or '',
@@ -173,18 +173,23 @@ class AppStatus:
             address=d.get('address') or '',
             life=d.get('life') or '',
             app_status=(
-                StatusInfoContents.from_dict(d['application-status'])
+                StatusInfoContents._from_dict(d['application-status'])
                 if 'application-status' in d
                 else StatusInfoContents()
             ),
             relations=(
-                {k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()}
+                {
+                    k: [AppStatusRelation._from_dict(x) for x in v]
+                    for k, v in d['relations'].items()
+                }
                 if 'relations' in d
                 else {}
             ),
             subordinate_to=d.get('subordinate-to') or [],
             units=(
-                {k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {}
+                {k: UnitStatus._from_dict(v) for k, v in d['units'].items()}
+                if 'units' in d
+                else {}
             ),
             version=d.get('version') or '',
             endpoint_bindings=d.get('endpoint-bindings') or {},
@@ -223,7 +228,7 @@ class EntityStatus:
     since: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> EntityStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> EntityStatus:
         return cls(
             current=d.get('current') or '',
             message=d.get('message') or '',
@@ -238,7 +243,7 @@ class UnitStorageAttachment:
     life: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> UnitStorageAttachment:
+    def _from_dict(cls, d: dict[str, Any]) -> UnitStorageAttachment:
         return cls(
             machine=d.get('machine') or '',
             location=d.get('location') or '',
@@ -251,9 +256,9 @@ class StorageAttachments:
     units: dict[str, UnitStorageAttachment]
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> StorageAttachments:
+    def _from_dict(cls, d: dict[str, Any]) -> StorageAttachments:
         return cls(
-            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()},
+            units={k: UnitStorageAttachment._from_dict(v) for k, v in d['units'].items()},
         )
 
 
@@ -267,14 +272,14 @@ class StorageInfo:
     attachments: StorageAttachments | None = None
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
+    def _from_dict(cls, d: dict[str, Any]) -> StorageInfo:
         return cls(
             kind=d['kind'],
-            status=EntityStatus.from_dict(d['status']),
+            status=EntityStatus._from_dict(d['status']),
             persistent=d['persistent'],
             life=d.get('life') or '',
             attachments=(
-                StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None
+                StorageAttachments._from_dict(d['attachments']) if 'attachments' in d else None
             ),
         )
 
@@ -287,7 +292,7 @@ class FilesystemAttachment:
     life: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachment:
+    def _from_dict(cls, d: dict[str, Any]) -> FilesystemAttachment:
         return cls(
             mount_point=d['mount-point'],
             read_only=d['read-only'],
@@ -302,20 +307,20 @@ class FilesystemAttachments:
     units: dict[str, UnitStorageAttachment] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
+    def _from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
         return cls(
             machines=(
-                {k: FilesystemAttachment.from_dict(v) for k, v in d['machines'].items()}
+                {k: FilesystemAttachment._from_dict(v) for k, v in d['machines'].items()}
                 if 'machines' in d
                 else {}
             ),
             containers=(
-                {k: FilesystemAttachment.from_dict(v) for k, v in d['containers'].items()}
+                {k: FilesystemAttachment._from_dict(v) for k, v in d['containers'].items()}
                 if 'containers' in d
                 else {}
             ),
             units=(
-                {k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()}
+                {k: UnitStorageAttachment._from_dict(v) for k, v in d['units'].items()}
                 if 'units' in d
                 else {}
             ),
@@ -335,20 +340,20 @@ class FilesystemInfo:
     status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
+    def _from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
         return cls(
             size=d['size'],
             provider_id=d.get('provider-id') or '',
             volume=d.get('volume') or '',
             storage=d.get('storage') or '',
             attachments=(
-                FilesystemAttachments.from_dict(d['attachments'])
+                FilesystemAttachments._from_dict(d['attachments'])
                 if 'attachments' in d
                 else FilesystemAttachments()
             ),
             pool=d.get('pool') or '',
             life=d.get('life') or '',
-            status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
+            status=EntityStatus._from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
 
 
@@ -362,7 +367,7 @@ class VolumeAttachment:
     life: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
+    def _from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
         return cls(
             read_only=d['read-only'],
             device=d.get('device') or '',
@@ -379,20 +384,20 @@ class VolumeAttachments:
     units: dict[str, UnitStorageAttachment] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
+    def _from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
         return cls(
             machines=(
-                {k: VolumeAttachment.from_dict(v) for k, v in d['machines'].items()}
+                {k: VolumeAttachment._from_dict(v) for k, v in d['machines'].items()}
                 if 'machines' in d
                 else {}
             ),
             containers=(
-                {k: VolumeAttachment.from_dict(v) for k, v in d['containers'].items()}
+                {k: VolumeAttachment._from_dict(v) for k, v in d['containers'].items()}
                 if 'containers' in d
                 else {}
             ),
             units=(
-                {k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()}
+                {k: UnitStorageAttachment._from_dict(v) for k, v in d['units'].items()}
                 if 'units' in d
                 else {}
             ),
@@ -414,14 +419,14 @@ class VolumeInfo:
     status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
+    def _from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
         return cls(
             size=d['size'],
             persistent=d['persistent'],
             provider_id=d.get('provider-id') or '',
             storage=d.get('storage') or '',
             attachments=(
-                VolumeAttachments.from_dict(d['attachments'])
+                VolumeAttachments._from_dict(d['attachments'])
                 if 'attachments' in d
                 else VolumeAttachments()
             ),
@@ -429,7 +434,7 @@ class VolumeInfo:
             hardware_id=d.get('hardware-id') or '',
             wwn=d.get('wwn') or '',
             life=d.get('life') or '',
-            status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
+            status=EntityStatus._from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
 
 
@@ -440,20 +445,20 @@ class CombinedStorage:
     volumes: dict[str, VolumeInfo] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
+    def _from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
         return cls(
             storage=(
-                {k: StorageInfo.from_dict(v) for k, v in d['storage'].items()}
+                {k: StorageInfo._from_dict(v) for k, v in d['storage'].items()}
                 if 'storage' in d
                 else {}
             ),
             filesystems=(
-                {k: FilesystemInfo.from_dict(v) for k, v in d['filesystems'].items()}
+                {k: FilesystemInfo._from_dict(v) for k, v in d['filesystems'].items()}
                 if 'filesystems' in d
                 else {}
             ),
             volumes=(
-                {k: VolumeInfo.from_dict(v) for k, v in d['volumes'].items()}
+                {k: VolumeInfo._from_dict(v) for k, v in d['volumes'].items()}
                 if 'volumes' in d
                 else {}
             ),
@@ -465,7 +470,7 @@ class ControllerStatus:
     timestamp: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ControllerStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> ControllerStatus:
         return cls(
             timestamp=d.get('timestamp') or '',
         )
@@ -478,7 +483,7 @@ class LxdProfileContents:
     devices: dict[str, dict[str, str]]
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
+    def _from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
         return cls(
             config=d['config'],
             description=d['description'],
@@ -497,7 +502,7 @@ class NetworkInterface:
     space: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
+    def _from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
         return cls(
             ip_addresses=d['ip-addresses'],
             mac_address=d['mac-address'],
@@ -528,12 +533,12 @@ class MachineStatus:
     lxd_profiles: dict[str, LxdProfileContents] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> MachineStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> MachineStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
             juju_status=(
-                StatusInfoContents.from_dict(d['juju-status'])
+                StatusInfoContents._from_dict(d['juju-status'])
                 if 'juju-status' in d
                 else StatusInfoContents()
             ),
@@ -543,23 +548,23 @@ class MachineStatus:
             instance_id=d.get('instance-id') or '',
             display_name=d.get('display-name') or '',
             machine_status=(
-                StatusInfoContents.from_dict(d['machine-status'])
+                StatusInfoContents._from_dict(d['machine-status'])
                 if 'machine-status' in d
                 else StatusInfoContents()
             ),
             modification_status=(
-                StatusInfoContents.from_dict(d['modification-status'])
+                StatusInfoContents._from_dict(d['modification-status'])
                 if 'modification-status' in d
                 else StatusInfoContents()
             ),
-            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
+            base=FormattedBase._from_dict(d['base']) if 'base' in d else None,
             network_interfaces=(
-                {k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()}
+                {k: NetworkInterface._from_dict(v) for k, v in d['network-interfaces'].items()}
                 if 'network-interfaces' in d
                 else {}
             ),
             containers=(
-                {k: MachineStatus.from_dict(v) for k, v in d['containers'].items()}
+                {k: MachineStatus._from_dict(v) for k, v in d['containers'].items()}
                 if 'containers' in d
                 else {}
             ),
@@ -568,7 +573,7 @@ class MachineStatus:
             controller_member_status=d.get('controller-member-status') or '',
             ha_primary=d.get('ha-primary') or False,
             lxd_profiles=(
-                {k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()}
+                {k: LxdProfileContents._from_dict(v) for k, v in d['lxd-profiles'].items()}
                 if 'lxd-profiles' in d
                 else {}
             ),
@@ -588,7 +593,7 @@ class ModelStatus:
     model_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> ModelStatus:
         return cls(
             name=d['name'],
             type=d['type'],
@@ -598,7 +603,7 @@ class ModelStatus:
             region=d.get('region') or '',
             upgrade_available=d.get('upgrade-available') or '',
             model_status=(
-                StatusInfoContents.from_dict(d['model-status'])
+                StatusInfoContents._from_dict(d['model-status'])
                 if 'model-status' in d
                 else StatusInfoContents()
             ),
@@ -611,7 +616,7 @@ class RemoteEndpoint:
     role: str
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> RemoteEndpoint:
+    def _from_dict(cls, d: dict[str, Any]) -> RemoteEndpoint:
         return cls(
             interface=d['interface'],
             role=d['role'],
@@ -628,12 +633,12 @@ class OfferStatus:
     active_connected_count: int = 0
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> OfferStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
             app=d['application'],
-            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
+            endpoints={k: RemoteEndpoint._from_dict(v) for k, v in d['endpoints'].items()},
             charm=d.get('charm') or '',
             total_connected_count=d.get('total-connected-count') or 0,
             active_connected_count=d.get('active-connected-count') or 0,
@@ -650,19 +655,19 @@ class RemoteAppStatus:
     relations: dict[str, list[str]] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
             url=d['url'],
             endpoints=(
-                {k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()}
+                {k: RemoteEndpoint._from_dict(v) for k, v in d['endpoints'].items()}
                 if 'endpoints' in d
                 else {}
             ),
             life=d.get('life') or '',
             app_status=(
-                StatusInfoContents.from_dict(d['application-status'])
+                StatusInfoContents._from_dict(d['application-status'])
                 if 'application-status' in d
                 else StatusInfoContents()
             ),
@@ -682,26 +687,26 @@ class Status:
     controller: ControllerStatus = dataclasses.field(default_factory=ControllerStatus)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Status:
+    def _from_dict(cls, d: dict[str, Any]) -> Status:
         return cls(
-            model=ModelStatus.from_dict(d['model']),
-            machines={k: MachineStatus.from_dict(v) for k, v in d['machines'].items()},
-            apps={k: AppStatus.from_dict(v) for k, v in d['applications'].items()},
+            model=ModelStatus._from_dict(d['model']),
+            machines={k: MachineStatus._from_dict(v) for k, v in d['machines'].items()},
+            apps={k: AppStatus._from_dict(v) for k, v in d['applications'].items()},
             app_endpoints=(
-                {k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()}
+                {k: RemoteAppStatus._from_dict(v) for k, v in d['application-endpoints'].items()}
                 if 'application-endpoints' in d
                 else {}
             ),
             offers=(
-                {k: OfferStatus.from_dict(v) for k, v in d['offers'].items()}
+                {k: OfferStatus._from_dict(v) for k, v in d['offers'].items()}
                 if 'offers' in d
                 else {}
             ),
             storage=(
-                CombinedStorage.from_dict(d['storage']) if 'storage' in d else CombinedStorage()
+                CombinedStorage._from_dict(d['storage']) if 'storage' in d else CombinedStorage()
             ),
             controller=(
-                ControllerStatus.from_dict(d['controller'])
+                ControllerStatus._from_dict(d['controller'])
                 if 'controller' in d
                 else ControllerStatus()
             ),

--- a/structs.py
+++ b/structs.py
@@ -3,7 +3,7 @@ import dataclasses
 from typing import Any
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class FormattedBase:
     name: str
     channel: str
@@ -16,7 +16,7 @@ class FormattedBase:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class StatusInfoContents:
     current: str | None = None
     message: str | None = None
@@ -37,7 +37,7 @@ class StatusInfoContents:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class AppStatusRelation:
     related_app: str | None = None
     interface: str | None = None
@@ -52,7 +52,7 @@ class AppStatusRelation:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class MeterStatus:
     color: str | None = None
     message: str | None = None
@@ -65,7 +65,7 @@ class MeterStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class UnitStatus:
     workload_status: StatusInfoContents | None = None
     juju_status: StatusInfoContents | None = None
@@ -98,7 +98,7 @@ class UnitStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class AppStatus:
     charm: str
     charm_origin: str
@@ -148,7 +148,7 @@ class AppStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class BranchStatus:
     ref: str | None = None
     created: str | None = None
@@ -165,7 +165,7 @@ class BranchStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class EntityStatus:
     current: str | None = None
     message: str | None = None
@@ -180,7 +180,7 @@ class EntityStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class UnitStorageAttachment:
     machine: str | None = None
     location: str | None = None
@@ -195,7 +195,7 @@ class UnitStorageAttachment:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class StorageAttachments:
     units: dict[str, UnitStorageAttachment]
 
@@ -206,7 +206,7 @@ class StorageAttachments:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class StorageInfo:
     kind: str
     status: EntityStatus
@@ -226,7 +226,7 @@ class StorageInfo:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class FilesystemAttachment:
     mount_point: str
     read_only: bool
@@ -242,7 +242,7 @@ class FilesystemAttachment:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class FilesystemAttachments:
     machines: dict[str, FilesystemAttachment] = dataclasses.field(default_factory=dict)
     containers: dict[str, FilesystemAttachment] = dataclasses.field(default_factory=dict)
@@ -257,7 +257,7 @@ class FilesystemAttachments:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class FilesystemInfo:
     Attachments: FilesystemAttachments
     size: int
@@ -283,7 +283,7 @@ class FilesystemInfo:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class VolumeAttachment:
     read_only: bool
 
@@ -303,7 +303,7 @@ class VolumeAttachment:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class VolumeAttachments:
     machines: dict[str, VolumeAttachment] = dataclasses.field(default_factory=dict)
     containers: dict[str, VolumeAttachment] = dataclasses.field(default_factory=dict)
@@ -318,7 +318,7 @@ class VolumeAttachments:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class VolumeInfo:
     size: int
     persistent: bool
@@ -348,7 +348,7 @@ class VolumeInfo:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CombinedStorage:
     storage: dict[str, StorageInfo] = dataclasses.field(default_factory=dict)
     filesystems: dict[str, FilesystemInfo] = dataclasses.field(default_factory=dict)
@@ -363,7 +363,7 @@ class CombinedStorage:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class ControllerStatus:
     timestamp: str | None = None
 
@@ -374,7 +374,7 @@ class ControllerStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class ModelStatus:
     name: str
     type: str
@@ -404,7 +404,7 @@ class ModelStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class NetworkInterface:
     ip_addresses: list[str]
     mac_address: str
@@ -426,7 +426,7 @@ class NetworkInterface:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class LxdProfileContents:
     config: dict[str, str]
     description: str
@@ -441,7 +441,7 @@ class LxdProfileContents:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class MachineStatus:
     juju_status: StatusInfoContents | None = None
     hostname: str | None = None
@@ -482,7 +482,7 @@ class MachineStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class RemoteEndpoint:
     interface: str
     role: str
@@ -495,7 +495,7 @@ class RemoteEndpoint:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class RemoteAppStatus:
     url: str
 
@@ -515,7 +515,7 @@ class RemoteAppStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class OfferStatus:
     app: str
     endpoints: dict[str, RemoteEndpoint]
@@ -535,7 +535,7 @@ class OfferStatus:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class FormattedStatus:
     model: ModelStatus
     machines: dict[str, MachineStatus]

--- a/structs.py
+++ b/structs.py
@@ -417,32 +417,17 @@ class ControllerStatus:
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class ModelStatus:
-    name: str
-    type: str
-    controller: str
-    cloud: str
-    version: str
-
-    region: str = ''
-    upgrade_available: str = ''
-    model_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+class LxdProfileContents:
+    config: dict[str, str]
+    description: str
+    devices: dict[str, dict[str, str]]
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
+    def from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
         return cls(
-            name=d['name'],
-            type=d['type'],
-            controller=d['controller'],
-            cloud=d['cloud'],
-            region=d.get('region') or '',
-            version=d['version'],
-            upgrade_available=d.get('upgrade-available') or '',
-            model_status=(
-                StatusInfoContents.from_dict(d['model-status'])
-                if 'model-status' in d
-                else StatusInfoContents()
-            ),
+            config=d['config'],
+            description=d['description'],
+            devices=d['devices'],
         )
 
 
@@ -465,21 +450,6 @@ class NetworkInterface:
             dns_nameservers=d.get('dns-nameservers') or [],
             space=d.get('space') or '',
             is_up=d['is-up'],
-        )
-
-
-@dataclasses.dataclass(frozen=True, kw_only=True)
-class LxdProfileContents:
-    config: dict[str, str]
-    description: str
-    devices: dict[str, dict[str, str]]
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
-        return cls(
-            config=d['config'],
-            description=d['description'],
-            devices=d['devices'],
         )
 
 
@@ -551,6 +521,36 @@ class MachineStatus:
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
+class ModelStatus:
+    name: str
+    type: str
+    controller: str
+    cloud: str
+    version: str
+
+    region: str = ''
+    upgrade_available: str = ''
+    model_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
+        return cls(
+            name=d['name'],
+            type=d['type'],
+            controller=d['controller'],
+            cloud=d['cloud'],
+            region=d.get('region') or '',
+            version=d['version'],
+            upgrade_available=d.get('upgrade-available') or '',
+            model_status=(
+                StatusInfoContents.from_dict(d['model-status'])
+                if 'model-status' in d
+                else StatusInfoContents()
+            ),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class RemoteEndpoint:
     interface: str
     role: str
@@ -560,6 +560,28 @@ class RemoteEndpoint:
         return cls(
             interface=d['interface'],
             role=d['role'],
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class OfferStatus:
+    app: str
+    endpoints: dict[str, RemoteEndpoint]
+
+    charm: str = ''
+    total_connected_count: int = 0
+    active_connected_count: int = 0
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
+        if 'status-error' in d:
+            raise StatusError(d['status-error'])
+        return cls(
+            app=d['application'],
+            charm=d.get('charm') or '',
+            total_connected_count=d.get('total-connected-count') or 0,
+            active_connected_count=d.get('active-connected-count') or 0,
+            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
         )
 
 
@@ -594,29 +616,7 @@ class RemoteAppStatus:
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class OfferStatus:
-    app: str
-    endpoints: dict[str, RemoteEndpoint]
-
-    charm: str = ''
-    total_connected_count: int = 0
-    active_connected_count: int = 0
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
-        if 'status-error' in d:
-            raise StatusError(d['status-error'])
-        return cls(
-            app=d['application'],
-            charm=d.get('charm') or '',
-            total_connected_count=d.get('total-connected-count') or 0,
-            active_connected_count=d.get('active-connected-count') or 0,
-            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
-        )
-
-
-@dataclasses.dataclass(frozen=True, kw_only=True)
-class FormattedStatus:
+class Status:
     model: ModelStatus
     machines: dict[str, MachineStatus]
     apps: dict[str, AppStatus]
@@ -627,7 +627,7 @@ class FormattedStatus:
     controller: ControllerStatus = dataclasses.field(default_factory=ControllerStatus)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FormattedStatus:
+    def from_dict(cls, d: dict[str, Any]) -> Status:
         return cls(
             model=ModelStatus.from_dict(d['model']),
             machines={k: MachineStatus.from_dict(v) for k, v in d['machines'].items()},

--- a/structs.py
+++ b/structs.py
@@ -70,7 +70,7 @@ class UnitStatus:
     workload_status: StatusInfoContents | None = None
     juju_status: StatusInfoContents | None = None
     meter_status: MeterStatus | None = None
-    leader: bool | None = None
+    leader: bool = False
     upgrading_from: str | None = None
     machine: str | None = None
     open_ports: list[str] = dataclasses.field(default_factory=list)
@@ -86,7 +86,7 @@ class UnitStatus:
             workload_status=StatusInfoContents.from_dict(d['workload-status']) if 'workload-status' in d else None,
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
             meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else None,
-            leader=d.get('leader'),
+            leader=d.get('leader') or False,
             upgrading_from=d.get('upgrading-from'),
             machine=d.get('machine'),
             open_ports=d.get('open-ports') or [],
@@ -153,7 +153,7 @@ class BranchStatus:
     ref: str | None = None
     created: str | None = None
     created_by: str | None = None
-    active: bool | None = None
+    active: bool = False
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> BranchStatus:
@@ -161,7 +161,7 @@ class BranchStatus:
             ref=d.get('ref'),
             created=d.get('created'),
             created_by=d.get('created-by'),
-            active=d.get('active'),
+            active=d.get('active') or False,
         )
 
 
@@ -457,7 +457,7 @@ class MachineStatus:
     constraints: str | None = None
     hardware: str | None = None
     controller_member_status: str | None = None
-    ha_primary: bool | None = None
+    ha_primary: bool = False
     lxd_profiles: dict[str, LxdProfileContents] = dataclasses.field(default_factory=dict)
 
     @classmethod
@@ -477,7 +477,7 @@ class MachineStatus:
             constraints=d.get('constraints'),
             hardware=d.get('hardware'),
             controller_member_status=d.get('controller-member-status'),
-            ha_primary=d.get('ha-primary'),
+            ha_primary=d.get('ha-primary') or False,
             lxd_profiles={k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()} if 'lxd-profiles' in d else {},
         )
 

--- a/structs.py
+++ b/structs.py
@@ -18,52 +18,52 @@ class FormattedBase:
 
 @dataclasses.dataclass(frozen=True)
 class StatusInfoContents:
-    current: str | None = None
-    message: str | None = None
-    reason: str | None = None
-    since: str | None = None
-    version: str | None = None
-    life: str | None = None
+    current: str = ''
+    message: str = ''
+    reason: str = ''
+    since: str = ''
+    version: str = ''
+    life: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
         if 'status-error' in d:
             raise Exception(d['status-error'])
         return cls(
-            current=d.get('current'),
-            message=d.get('message'),
-            reason=d.get('reason'),
-            since=d.get('since'),
-            version=d.get('version'),
-            life=d.get('life'),
+            current=d.get('current') or '',
+            message=d.get('message') or '',
+            reason=d.get('reason') or '',
+            since=d.get('since') or '',
+            version=d.get('version') or '',
+            life=d.get('life') or '',
         )
 
 
 @dataclasses.dataclass(frozen=True)
 class AppStatusRelation:
-    related_app: str | None = None
-    interface: str | None = None
-    scope: str | None = None
+    related_app: str = ''
+    interface: str = ''
+    scope: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
         return cls(
-            related_app=d.get('related-application'),
-            interface=d.get('interface'),
-            scope=d.get('scope'),
+            related_app=d.get('related-application') or '',
+            interface=d.get('interface') or '',
+            scope=d.get('scope') or '',
         )
 
 
 @dataclasses.dataclass(frozen=True)
 class MeterStatus:
-    color: str | None = None
-    message: str | None = None
+    color: str = ''
+    message: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> MeterStatus:
         return cls(
-            color=d.get('color'),
-            message=d.get('message'),
+            color=d.get('color') or '',
+            message=d.get('message') or '',
         )
 
 
@@ -73,14 +73,14 @@ class UnitStatus:
     juju_status: StatusInfoContents | None = None
     meter_status: MeterStatus | None = None
     leader: bool = False
-    upgrading_from: str | None = None
-    machine: str | None = None
+    upgrading_from: str = ''
+    machine: str = ''
     open_ports: list[str] = dataclasses.field(default_factory=list)
-    public_address: str | None = None
-    address: str | None = None
-    provider_id: str | None = None
+    public_address: str = ''
+    address: str = ''
+    provider_id: str = ''
     subordinates: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
-    branch: str | None = None
+    branch: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
@@ -91,14 +91,14 @@ class UnitStatus:
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
             meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else None,
             leader=d.get('leader') or False,
-            upgrading_from=d.get('upgrading-from'),
-            machine=d.get('machine'),
+            upgrading_from=d.get('upgrading-from') or '',
+            machine=d.get('machine') or '',
             open_ports=d.get('open-ports') or [],
-            public_address=d.get('public-address'),
-            address=d.get('address'),
-            provider_id=d.get('provider-id'),
+            public_address=d.get('public-address') or '',
+            address=d.get('address') or '',
+            provider_id=d.get('provider-id') or '',
             subordinates={k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()} if 'subordinates' in d else {},
-            branch=d.get('branch'),
+            branch=d.get('branch') or '',
         )
 
 
@@ -111,19 +111,19 @@ class AppStatus:
     exposed: bool
 
     base: FormattedBase | None = None
-    charm_channel: str | None = None
-    charm_version: str | None = None
-    charm_profile: str | None = None
-    can_upgrade_to: str | None = None
-    scale: int | None = None
-    provider_id: str | None = None
-    address: str | None = None
-    life: str | None = None
+    charm_channel: str = ''
+    charm_version: str = ''
+    charm_profile: str = ''
+    can_upgrade_to: str = ''
+    scale: int = 0
+    provider_id: str = ''
+    address: str = ''
+    life: str = ''
     app_status: StatusInfoContents | None = None
     relations: dict[str, list[AppStatusRelation]] = dataclasses.field(default_factory=dict)
     subordinate_to: list[str] = dataclasses.field(default_factory=list)
     units: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
-    version: str | None = None
+    version: str = ''
     endpoint_bindings: dict[str, str] = dataclasses.field(default_factory=dict)
 
     @classmethod
@@ -136,68 +136,68 @@ class AppStatus:
             charm_origin=d['charm-origin'],
             charm_name=d['charm-name'],
             charm_rev=d['charm-rev'],
-            charm_channel=d.get('charm-channel'),
-            charm_version=d.get('charm-version'),
-            charm_profile=d.get('charm-profile'),
-            can_upgrade_to=d.get('can-upgrade-to'),
-            scale=d.get('scale'),
-            provider_id=d.get('provider-id'),
-            address=d.get('address'),
+            charm_channel=d.get('charm-channel') or '',
+            charm_version=d.get('charm-version') or '',
+            charm_profile=d.get('charm-profile') or '',
+            can_upgrade_to=d.get('can-upgrade-to') or '',
+            scale=d.get('scale') or 0,
+            provider_id=d.get('provider-id') or '',
+            address=d.get('address') or '',
             exposed=d['exposed'],
-            life=d.get('life'),
+            life=d.get('life') or '',
             app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
             relations={k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()} if 'relations' in d else {},
             subordinate_to=d.get('subordinate-to') or [],
             units={k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
-            version=d.get('version'),
+            version=d.get('version') or '',
             endpoint_bindings=d.get('endpoint-bindings') or {},
         )
 
 
 @dataclasses.dataclass(frozen=True)
 class BranchStatus:
-    ref: str | None = None
-    created: str | None = None
-    created_by: str | None = None
+    ref: str = ''
+    created: str = ''
+    created_by: str = ''
     active: bool = False
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> BranchStatus:
         return cls(
-            ref=d.get('ref'),
-            created=d.get('created'),
-            created_by=d.get('created-by'),
+            ref=d.get('ref') or '',
+            created=d.get('created') or '',
+            created_by=d.get('created-by') or '',
             active=d.get('active') or False,
         )
 
 
 @dataclasses.dataclass(frozen=True)
 class EntityStatus:
-    current: str | None = None
-    message: str | None = None
-    since: str | None = None
+    current: str = ''
+    message: str = ''
+    since: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> EntityStatus:
         return cls(
-            current=d.get('current'),
-            message=d.get('message'),
-            since=d.get('since'),
+            current=d.get('current') or '',
+            message=d.get('message') or '',
+            since=d.get('since') or '',
         )
 
 
 @dataclasses.dataclass(frozen=True)
 class UnitStorageAttachment:
-    machine: str | None = None
-    location: str | None = None
-    life: str | None = None
+    machine: str = ''
+    location: str = ''
+    life: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> UnitStorageAttachment:
         return cls(
-            machine=d.get('machine'),
-            location=d.get('location'),
-            life=d.get('life'),
+            machine=d.get('machine') or '',
+            location=d.get('location') or '',
+            life=d.get('life') or '',
         )
 
 
@@ -218,14 +218,14 @@ class StorageInfo:
     status: EntityStatus
     persistent: bool
 
-    life: str | None = None
+    life: str = ''
     attachments: StorageAttachments | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
         return cls(
             kind=d['kind'],
-            life=d.get('life'),
+            life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']),
             persistent=d['persistent'],
             attachments=StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None,
@@ -237,14 +237,14 @@ class FilesystemAttachment:
     mount_point: str
     read_only: bool
 
-    life: str | None = None
+    life: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachment:
         return cls(
             mount_point=d['mount-point'],
             read_only=d['read-only'],
-            life=d.get('life'),
+            life=d.get('life') or '',
         )
 
 
@@ -268,23 +268,23 @@ class FilesystemInfo:
     Attachments: FilesystemAttachments
     size: int
 
-    provider_id: str | None = None
-    volume: str | None = None
-    storage: str | None = None
-    pool: str | None = None
-    life: str | None = None
+    provider_id: str = ''
+    volume: str = ''
+    storage: str = ''
+    pool: str = ''
+    life: str = ''
     status: EntityStatus | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
         return cls(
-            provider_id=d.get('provider-id'),
-            volume=d.get('volume'),
-            storage=d.get('storage'),
+            provider_id=d.get('provider-id') or '',
+            volume=d.get('volume') or '',
+            storage=d.get('storage') or '',
             Attachments=FilesystemAttachments.from_dict(d['Attachments']),
-            pool=d.get('pool'),
+            pool=d.get('pool') or '',
             size=d['size'],
-            life=d.get('life'),
+            life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']) if 'status' in d else None,
         )
 
@@ -293,19 +293,19 @@ class FilesystemInfo:
 class VolumeAttachment:
     read_only: bool
 
-    device: str | None = None
-    device_link: str | None = None
-    bus_address: str | None = None
-    life: str | None = None
+    device: str = ''
+    device_link: str = ''
+    bus_address: str = ''
+    life: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
         return cls(
-            device=d.get('device'),
-            device_link=d.get('device-link'),
-            bus_address=d.get('bus-address'),
+            device=d.get('device') or '',
+            device_link=d.get('device-link') or '',
+            bus_address=d.get('bus-address') or '',
             read_only=d['read-only'],
-            life=d.get('life'),
+            life=d.get('life') or '',
         )
 
 
@@ -329,27 +329,27 @@ class VolumeInfo:
     size: int
     persistent: bool
 
-    provider_id: str | None = None
-    storage: str | None = None
+    provider_id: str = ''
+    storage: str = ''
     attachments: VolumeAttachments | None = None
-    pool: str | None = None
-    hardware_id: str | None = None
-    wwn: str | None = None
-    life: str | None = None
+    pool: str = ''
+    hardware_id: str = ''
+    wwn: str = ''
+    life: str = ''
     status: EntityStatus | None = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
         return cls(
-            provider_id=d.get('provider-id'),
-            storage=d.get('storage'),
+            provider_id=d.get('provider-id') or '',
+            storage=d.get('storage') or '',
             attachments=VolumeAttachments.from_dict(d['attachments']) if 'attachments' in d else None,
-            pool=d.get('pool'),
-            hardware_id=d.get('hardware-id'),
-            wwn=d.get('wwn'),
+            pool=d.get('pool') or '',
+            hardware_id=d.get('hardware-id') or '',
+            wwn=d.get('wwn') or '',
             size=d['size'],
             persistent=d['persistent'],
-            life=d.get('life'),
+            life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']) if 'status' in d else None,
         )
 
@@ -371,12 +371,12 @@ class CombinedStorage:
 
 @dataclasses.dataclass(frozen=True)
 class ControllerStatus:
-    timestamp: str | None = None
+    timestamp: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> ControllerStatus:
         return cls(
-            timestamp=d.get('timestamp'),
+            timestamp=d.get('timestamp') or '',
         )
 
 
@@ -388,11 +388,11 @@ class ModelStatus:
     cloud: str
     version: str
 
-    region: str | None = None
-    upgrade_available: str | None = None
+    region: str = ''
+    upgrade_available: str = ''
     model_status: StatusInfoContents | None = None
     meter_status: MeterStatus | None = None
-    sla: str | None = None
+    sla: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
@@ -401,12 +401,12 @@ class ModelStatus:
             type=d['type'],
             controller=d['controller'],
             cloud=d['cloud'],
-            region=d.get('region'),
+            region=d.get('region') or '',
             version=d['version'],
-            upgrade_available=d.get('upgrade-available'),
+            upgrade_available=d.get('upgrade-available') or '',
             model_status=StatusInfoContents.from_dict(d['model-status']) if 'model-status' in d else None,
             meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else None,
-            sla=d.get('sla'),
+            sla=d.get('sla') or '',
         )
 
 
@@ -416,18 +416,18 @@ class NetworkInterface:
     mac_address: str
     is_up: bool
 
-    gateway: str | None = None
+    gateway: str = ''
     dns_nameservers: list[str] = dataclasses.field(default_factory=list)
-    space: str | None = None
+    space: str = ''
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
         return cls(
             ip_addresses=d['ip-addresses'],
             mac_address=d['mac-address'],
-            gateway=d.get('gateway'),
+            gateway=d.get('gateway') or '',
             dns_nameservers=d.get('dns-nameservers') or [],
-            space=d.get('space'),
+            space=d.get('space') or '',
             is_up=d['is-up'],
         )
 
@@ -450,19 +450,19 @@ class LxdProfileContents:
 @dataclasses.dataclass(frozen=True)
 class MachineStatus:
     juju_status: StatusInfoContents | None = None
-    hostname: str | None = None
-    dns_name: str | None = None
+    hostname: str = ''
+    dns_name: str = ''
     ip_addresses: list[str] = dataclasses.field(default_factory=list)
-    instance_id: str | None = None
-    display_name: str | None = None
+    instance_id: str = ''
+    display_name: str = ''
     machine_status: StatusInfoContents | None = None
     modification_status: StatusInfoContents | None = None
     base: FormattedBase | None = None
     network_interfaces: dict[str, NetworkInterface] = dataclasses.field(default_factory=dict)
     containers: dict[str, MachineStatus] = dataclasses.field(default_factory=dict)
-    constraints: str | None = None
-    hardware: str | None = None
-    controller_member_status: str | None = None
+    constraints: str = ''
+    hardware: str = ''
+    controller_member_status: str = ''
     ha_primary: bool = False
     lxd_profiles: dict[str, LxdProfileContents] = dataclasses.field(default_factory=dict)
 
@@ -472,19 +472,19 @@ class MachineStatus:
             raise Exception(d['status-error'])
         return cls(
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
-            hostname=d.get('hostname'),
-            dns_name=d.get('dns-name'),
+            hostname=d.get('hostname') or '',
+            dns_name=d.get('dns-name') or '',
             ip_addresses=d.get('ip-addresses') or [],
-            instance_id=d.get('instance-id'),
-            display_name=d.get('display-name'),
+            instance_id=d.get('instance-id') or '',
+            display_name=d.get('display-name') or '',
             machine_status=StatusInfoContents.from_dict(d['machine-status']) if 'machine-status' in d else None,
             modification_status=StatusInfoContents.from_dict(d['modification-status']) if 'modification-status' in d else None,
             base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
             network_interfaces={k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()} if 'network-interfaces' in d else {},
             containers={k: MachineStatus.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else {},
-            constraints=d.get('constraints'),
-            hardware=d.get('hardware'),
-            controller_member_status=d.get('controller-member-status'),
+            constraints=d.get('constraints') or '',
+            hardware=d.get('hardware') or '',
+            controller_member_status=d.get('controller-member-status') or '',
             ha_primary=d.get('ha-primary') or False,
             lxd_profiles={k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()} if 'lxd-profiles' in d else {},
         )
@@ -508,7 +508,7 @@ class RemoteAppStatus:
     url: str
 
     endpoints: dict[str, RemoteEndpoint] = dataclasses.field(default_factory=dict)
-    life: str | None = None
+    life: str = ''
     app_status: StatusInfoContents | None = None
     relations: dict[str, list[str]] = dataclasses.field(default_factory=dict)
 
@@ -519,7 +519,7 @@ class RemoteAppStatus:
         return cls(
             url=d['url'],
             endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else {},
-            life=d.get('life'),
+            life=d.get('life') or '',
             app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
             relations=d.get('relations') or {},
         )
@@ -530,9 +530,9 @@ class OfferStatus:
     app: str
     endpoints: dict[str, RemoteEndpoint]
 
-    charm: str | None = None
-    total_connected_count: int | None = None
-    active_connected_count: int | None = None
+    charm: str = ''
+    total_connected_count: int = 0
+    active_connected_count: int = 0
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
@@ -540,9 +540,9 @@ class OfferStatus:
             raise Exception(d['status-error'])
         return cls(
             app=d['application'],
-            charm=d.get('charm'),
-            total_connected_count=d.get('total-connected-count'),
-            active_connected_count=d.get('active-connected-count'),
+            charm=d.get('charm') or '',
+            total_connected_count=d.get('total-connected-count') or 0,
+            active_connected_count=d.get('active-connected-count') or 0,
             endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
         )
 

--- a/structs.py
+++ b/structs.py
@@ -1,6 +1,12 @@
+"""Dataclasses used to hold parsed output from "juju status --format=json"."""
+
 from __future__ import annotations
 import dataclasses
 from typing import Any
+
+
+class StatusError(Exception):
+    """Raised when "juju status" returns a status-error for certain types."""
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -28,7 +34,7 @@ class StatusInfoContents:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
         if 'status-error' in d:
-            raise Exception(d['status-error'])
+            raise StatusError(d['status-error'])
         return cls(
             current=d.get('current') or '',
             message=d.get('message') or '',
@@ -70,7 +76,7 @@ class UnitStatus:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
         if 'status-error' in d:
-            raise Exception(d['status-error'])
+            raise StatusError(d['status-error'])
         return cls(
             workload_status=StatusInfoContents.from_dict(d['workload-status']) if 'workload-status' in d else StatusInfoContents(),
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else StatusInfoContents(),
@@ -112,7 +118,7 @@ class AppStatus:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> AppStatus:
         if 'status-error' in d:
-            raise Exception(d['status-error'])
+            raise StatusError(d['status-error'])
         return cls(
             charm=d['charm'],
             base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
@@ -431,7 +437,7 @@ class MachineStatus:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> MachineStatus:
         if 'status-error' in d:
-            raise Exception(d['status-error'])
+            raise StatusError(d['status-error'])
         return cls(
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else StatusInfoContents(),
             hostname=d.get('hostname') or '',
@@ -477,7 +483,7 @@ class RemoteAppStatus:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
         if 'status-error' in d:
-            raise Exception(d['status-error'])
+            raise StatusError(d['status-error'])
         return cls(
             url=d['url'],
             endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else {},
@@ -499,7 +505,7 @@ class OfferStatus:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
         if 'status-error' in d:
-            raise Exception(d['status-error'])
+            raise StatusError(d['status-error'])
         return cls(
             app=d['application'],
             charm=d.get('charm') or '',

--- a/structs.py
+++ b/structs.py
@@ -324,7 +324,7 @@ class FilesystemAttachments:
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FilesystemInfo:
-    Attachments: FilesystemAttachments
+    attachments: FilesystemAttachments
     size: int
 
     provider_id: str = ''
@@ -337,7 +337,7 @@ class FilesystemInfo:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
         return cls(
-            Attachments=FilesystemAttachments.from_dict(d['Attachments']),
+            attachments=FilesystemAttachments.from_dict(d['Attachments']),
             size=d['size'],
             provider_id=d.get('provider-id') or '',
             volume=d.get('volume') or '',

--- a/structs.py
+++ b/structs.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+import dataclasses
+from typing import Any
+
+
+@dataclasses.dataclass
+class FormattedBase:
+    name: str
+    channel: str
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FormattedBase:
+        return cls(
+            name=d['name'],
+            channel=d['channel'],
+        )
+
+
+@dataclasses.dataclass
+class StatusInfoContents:
+    current: str | None
+    message: str | None
+    reason: str | None
+    since: str | None
+    version: str | None
+    life: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
+        return cls(
+            current=d.get('current'),
+            message=d.get('message'),
+            reason=d.get('reason'),
+            since=d.get('since'),
+            version=d.get('version'),
+            life=d.get('life'),
+        )
+
+
+@dataclasses.dataclass
+class AppStatusRelation:
+    related_app: str | None
+    interface: str | None
+    scope: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
+        return cls(
+            related_app=d.get('related-application'),
+            interface=d.get('interface'),
+            scope=d.get('scope'),
+        )
+
+
+@dataclasses.dataclass
+class MeterStatus:
+    color: str | None
+    message: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> MeterStatus:
+        return cls(
+            color=d.get('color'),
+            message=d.get('message'),
+        )
+
+
+@dataclasses.dataclass
+class UnitStatus:
+    workload_status: StatusInfoContents
+    juju_status: StatusInfoContents
+    meter_status: MeterStatus
+    leader: bool | None
+    upgrading_from: str | None
+    machine: str | None
+    open_ports: list[str] | None
+    public_address: str | None
+    address: str | None
+    provider_id: str | None
+    subordinates: dict[str, UnitStatus] | None
+    branch: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
+        return cls(
+            workload_status=StatusInfoContents.from_dict(d['workload-status']) if 'workload-status' in d else None,
+            juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
+            meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else None,
+            leader=d.get('leader'),
+            upgrading_from=d.get('upgrading-from'),
+            machine=d.get('machine'),
+            open_ports=[x for x in d['open-ports']] if 'open-ports' in d else None,
+            public_address=d.get('public-address'),
+            address=d.get('address'),
+            provider_id=d.get('provider-id'),
+            subordinates={k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()} if 'subordinates' in d else None,
+            branch=d.get('branch'),
+        )
+
+
+@dataclasses.dataclass
+class AppStatus:
+    charm: str
+    base: FormattedBase
+    charm_origin: str
+    charm_name: str
+    charm_rev: int
+    charm_channel: str | None
+    charm_version: str | None
+    charm_profile: str | None
+    can_upgrade_to: str | None
+    scale: int | None
+    provider_id: str | None
+    address: str | None
+    exposed: bool
+    life: str | None
+    app_status: StatusInfoContents
+    relations: dict[str, list[AppStatusRelation]] | None
+    subordinate_to: list[str] | None
+    units: dict[str, UnitStatus] | None
+    version: str | None
+    endpoint_bindings: dict[str, str] | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AppStatus:
+        return cls(
+            charm=d['charm'],
+            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
+            charm_origin=d['charm-origin'],
+            charm_name=d['charm-name'],
+            charm_rev=d['charm-rev'],
+            charm_channel=d.get('charm-channel'),
+            charm_version=d.get('charm-version'),
+            charm_profile=d.get('charm-profile'),
+            can_upgrade_to=d.get('can-upgrade-to'),
+            scale=d.get('scale'),
+            provider_id=d.get('provider-id'),
+            address=d.get('address'),
+            exposed=d['exposed'],
+            life=d.get('life'),
+            app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
+            relations={k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()} if 'relations' in d else None,
+            subordinate_to=[x for x in d['subordinate-to']] if 'subordinate-to' in d else None,
+            units={k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else None,
+            version=d.get('version'),
+            endpoint_bindings={k: v for k, v in d['endpoint-bindings'].items()} if 'endpoint-bindings' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class BranchStatus:
+    ref: str | None
+    created: str | None
+    created_by: str | None
+    active: bool | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BranchStatus:
+        return cls(
+            ref=d.get('ref'),
+            created=d.get('created'),
+            created_by=d.get('created-by'),
+            active=d.get('active'),
+        )
+
+
+@dataclasses.dataclass
+class EntityStatus:
+    current: str | None
+    message: str | None
+    since: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> EntityStatus:
+        return cls(
+            current=d.get('current'),
+            message=d.get('message'),
+            since=d.get('since'),
+        )
+
+
+@dataclasses.dataclass
+class UnitStorageAttachment:
+    machine: str | None
+    location: str | None
+    life: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> UnitStorageAttachment:
+        return cls(
+            machine=d.get('machine'),
+            location=d.get('location'),
+            life=d.get('life'),
+        )
+
+
+@dataclasses.dataclass
+class StorageAttachments:
+    units: dict[str, UnitStorageAttachment]
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> StorageAttachments:
+        return cls(
+            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()},
+        )
+
+
+@dataclasses.dataclass
+class StorageInfo:
+    kind: str
+    life: str | None
+    status: EntityStatus
+    persistent: bool
+    attachments: StorageAttachments
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
+        return cls(
+            kind=d['kind'],
+            life=d.get('life'),
+            status=EntityStatus.from_dict(d['status']),
+            persistent=d['persistent'],
+            attachments=StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class FilesystemAttachment:
+    mount_point: str
+    read_only: bool
+    life: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachment:
+        return cls(
+            mount_point=d['mount-point'],
+            read_only=d['read-only'],
+            life=d.get('life'),
+        )
+
+
+@dataclasses.dataclass
+class FilesystemAttachments:
+    machines: dict[str, FilesystemAttachment] | None
+    containers: dict[str, FilesystemAttachment] | None
+    units: dict[str, UnitStorageAttachment] | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
+        return cls(
+            machines={k: FilesystemAttachment.from_dict(v) for k, v in d['machines'].items()} if 'machines' in d else None,
+            containers={k: FilesystemAttachment.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else None,
+            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()} if 'units' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class FilesystemInfo:
+    provider_id: str | None
+    volume: str | None
+    storage: str | None
+    Attachments: FilesystemAttachments
+    pool: str | None
+    size: int
+    life: str | None
+    status: EntityStatus
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
+        return cls(
+            provider_id=d.get('provider-id'),
+            volume=d.get('volume'),
+            storage=d.get('storage'),
+            Attachments=FilesystemAttachments.from_dict(d['Attachments']),
+            pool=d.get('pool'),
+            size=d['size'],
+            life=d.get('life'),
+            status=EntityStatus.from_dict(d['status']) if 'status' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class VolumeAttachment:
+    device: str | None
+    device_link: str | None
+    bus_address: str | None
+    read_only: bool
+    life: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
+        return cls(
+            device=d.get('device'),
+            device_link=d.get('device-link'),
+            bus_address=d.get('bus-address'),
+            read_only=d['read-only'],
+            life=d.get('life'),
+        )
+
+
+@dataclasses.dataclass
+class VolumeAttachments:
+    machines: dict[str, VolumeAttachment] | None
+    containers: dict[str, VolumeAttachment] | None
+    units: dict[str, UnitStorageAttachment] | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
+        return cls(
+            machines={k: VolumeAttachment.from_dict(v) for k, v in d['machines'].items()} if 'machines' in d else None,
+            containers={k: VolumeAttachment.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else None,
+            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()} if 'units' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class VolumeInfo:
+    provider_id: str | None
+    storage: str | None
+    attachments: VolumeAttachments
+    pool: str | None
+    hardware_id: str | None
+    wwn: str | None
+    size: int
+    persistent: bool
+    life: str | None
+    status: EntityStatus
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
+        return cls(
+            provider_id=d.get('provider-id'),
+            storage=d.get('storage'),
+            attachments=VolumeAttachments.from_dict(d['attachments']) if 'attachments' in d else None,
+            pool=d.get('pool'),
+            hardware_id=d.get('hardware-id'),
+            wwn=d.get('wwn'),
+            size=d['size'],
+            persistent=d['persistent'],
+            life=d.get('life'),
+            status=EntityStatus.from_dict(d['status']) if 'status' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class CombinedStorage:
+    storage: dict[str, StorageInfo] | None
+    filesystems: dict[str, FilesystemInfo] | None
+    volumes: dict[str, VolumeInfo] | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
+        return cls(
+            storage={k: StorageInfo.from_dict(v) for k, v in d['storage'].items()} if 'storage' in d else None,
+            filesystems={k: FilesystemInfo.from_dict(v) for k, v in d['filesystems'].items()} if 'filesystems' in d else None,
+            volumes={k: VolumeInfo.from_dict(v) for k, v in d['volumes'].items()} if 'volumes' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class ControllerStatus:
+    timestamp: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ControllerStatus:
+        return cls(
+            timestamp=d.get('timestamp'),
+        )
+
+
+@dataclasses.dataclass
+class ModelStatus:
+    name: str
+    type: str
+    controller: str
+    cloud: str
+    region: str | None
+    version: str
+    upgrade_available: str | None
+    model_status: StatusInfoContents
+    meter_status: MeterStatus
+    sla: str | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
+        return cls(
+            name=d['name'],
+            type=d['type'],
+            controller=d['controller'],
+            cloud=d['cloud'],
+            region=d.get('region'),
+            version=d['version'],
+            upgrade_available=d.get('upgrade-available'),
+            model_status=StatusInfoContents.from_dict(d['model-status']) if 'model-status' in d else None,
+            meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else None,
+            sla=d.get('sla'),
+        )
+
+
+@dataclasses.dataclass
+class NetworkInterface:
+    ip_addresses: list[str]
+    mac_address: str
+    gateway: str | None
+    dns_nameservers: list[str] | None
+    space: str | None
+    is_up: bool
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
+        return cls(
+            ip_addresses=[x for x in d['ip-addresses']],
+            mac_address=d['mac-address'],
+            gateway=d.get('gateway'),
+            dns_nameservers=[x for x in d['dns-nameservers']] if 'dns-nameservers' in d else None,
+            space=d.get('space'),
+            is_up=d['is-up'],
+        )
+
+
+@dataclasses.dataclass
+class LxdProfileContents:
+    config: dict[str, str]
+    description: str
+    devices: dict[str, dict[str, str]]
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
+        return cls(
+            config={k: v for k, v in d['config'].items()},
+            description=d['description'],
+            devices={k: {k: v for k, v in v.items()} for k, v in d['devices'].items()},
+        )
+
+
+@dataclasses.dataclass
+class MachineStatus:
+    juju_status: StatusInfoContents
+    hostname: str | None
+    dns_name: str | None
+    ip_addresses: list[str] | None
+    instance_id: str | None
+    display_name: str | None
+    machine_status: StatusInfoContents
+    modification_status: StatusInfoContents
+    base: FormattedBase
+    network_interfaces: dict[str, NetworkInterface] | None
+    containers: dict[str, MachineStatus] | None
+    constraints: str | None
+    hardware: str | None
+    controller_member_status: str | None
+    ha_primary: bool | None
+    lxd_profiles: dict[str, LxdProfileContents] | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> MachineStatus:
+        return cls(
+            juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
+            hostname=d.get('hostname'),
+            dns_name=d.get('dns-name'),
+            ip_addresses=[x for x in d['ip-addresses']] if 'ip-addresses' in d else None,
+            instance_id=d.get('instance-id'),
+            display_name=d.get('display-name'),
+            machine_status=StatusInfoContents.from_dict(d['machine-status']) if 'machine-status' in d else None,
+            modification_status=StatusInfoContents.from_dict(d['modification-status']) if 'modification-status' in d else None,
+            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
+            network_interfaces={k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()} if 'network-interfaces' in d else None,
+            containers={k: MachineStatus.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else None,
+            constraints=d.get('constraints'),
+            hardware=d.get('hardware'),
+            controller_member_status=d.get('controller-member-status'),
+            ha_primary=d.get('ha-primary'),
+            lxd_profiles={k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()} if 'lxd-profiles' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class RemoteEndpoint:
+    interface: str
+    role: str
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RemoteEndpoint:
+        return cls(
+            interface=d['interface'],
+            role=d['role'],
+        )
+
+
+@dataclasses.dataclass
+class RemoteAppStatus:
+    url: str
+    endpoints: dict[str, RemoteEndpoint] | None
+    life: str | None
+    app_status: StatusInfoContents
+    relations: dict[str, list[str]] | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
+        return cls(
+            url=d['url'],
+            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else None,
+            life=d.get('life'),
+            app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
+            relations={k: [x for x in v] for k, v in d['relations'].items()} if 'relations' in d else None,
+        )
+
+
+@dataclasses.dataclass
+class OfferStatus:
+    app: str
+    charm: str | None
+    total_connected_count: int | None
+    active_connected_count: int | None
+    endpoints: dict[str, RemoteEndpoint]
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
+        return cls(
+            app=d['application'],
+            charm=d.get('charm'),
+            total_connected_count=d.get('total-connected-count'),
+            active_connected_count=d.get('active-connected-count'),
+            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
+        )
+
+
+@dataclasses.dataclass
+class FormattedStatus:
+    model: ModelStatus
+    machines: dict[str, MachineStatus]
+    apps: dict[str, AppStatus]
+    app_endpoints: dict[str, RemoteAppStatus] | None
+    offers: dict[str, OfferStatus] | None
+    storage: CombinedStorage
+    controller: ControllerStatus
+    branches: dict[str, BranchStatus] | None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FormattedStatus:
+        return cls(
+            model=ModelStatus.from_dict(d['model']),
+            machines={k: MachineStatus.from_dict(v) for k, v in d['machines'].items()},
+            apps={k: AppStatus.from_dict(v) for k, v in d['applications'].items()},
+            app_endpoints={k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()} if 'application-endpoints' in d else None,
+            offers={k: OfferStatus.from_dict(v) for k, v in d['offers'].items()} if 'offers' in d else None,
+            storage=CombinedStorage.from_dict(d['storage']) if 'storage' in d else None,
+            controller=ControllerStatus.from_dict(d['controller']) if 'controller' in d else None,
+            branches={k: BranchStatus.from_dict(v) for k, v in d['branches'].items()} if 'branches' in d else None,
+        )

--- a/structs.py
+++ b/structs.py
@@ -3,7 +3,7 @@ import dataclasses
 from typing import Any
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class FormattedBase:
     name: str
     channel: str
@@ -16,7 +16,7 @@ class FormattedBase:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class StatusInfoContents:
     current: str = ''
     message: str = ''
@@ -39,7 +39,7 @@ class StatusInfoContents:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class AppStatusRelation:
     related_app: str = ''
     interface: str = ''
@@ -54,7 +54,7 @@ class AppStatusRelation:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class UnitStatus:
     workload_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
     juju_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
@@ -85,7 +85,7 @@ class UnitStatus:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class AppStatus:
     charm: str
     charm_origin: str
@@ -137,7 +137,7 @@ class AppStatus:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class EntityStatus:
     current: str = ''
     message: str = ''
@@ -152,7 +152,7 @@ class EntityStatus:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class UnitStorageAttachment:
     machine: str = ''
     location: str = ''
@@ -167,7 +167,7 @@ class UnitStorageAttachment:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class StorageAttachments:
     units: dict[str, UnitStorageAttachment]
 
@@ -178,7 +178,7 @@ class StorageAttachments:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class StorageInfo:
     kind: str
     status: EntityStatus
@@ -198,7 +198,7 @@ class StorageInfo:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class FilesystemAttachment:
     mount_point: str
     read_only: bool
@@ -214,7 +214,7 @@ class FilesystemAttachment:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class FilesystemAttachments:
     machines: dict[str, FilesystemAttachment] = dataclasses.field(default_factory=dict)
     containers: dict[str, FilesystemAttachment] = dataclasses.field(default_factory=dict)
@@ -229,7 +229,7 @@ class FilesystemAttachments:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class FilesystemInfo:
     Attachments: FilesystemAttachments
     size: int
@@ -255,7 +255,7 @@ class FilesystemInfo:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class VolumeAttachment:
     read_only: bool
 
@@ -275,7 +275,7 @@ class VolumeAttachment:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class VolumeAttachments:
     machines: dict[str, VolumeAttachment] = dataclasses.field(default_factory=dict)
     containers: dict[str, VolumeAttachment] = dataclasses.field(default_factory=dict)
@@ -290,7 +290,7 @@ class VolumeAttachments:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class VolumeInfo:
     size: int
     persistent: bool
@@ -320,7 +320,7 @@ class VolumeInfo:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class CombinedStorage:
     storage: dict[str, StorageInfo] = dataclasses.field(default_factory=dict)
     filesystems: dict[str, FilesystemInfo] = dataclasses.field(default_factory=dict)
@@ -335,7 +335,7 @@ class CombinedStorage:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class ControllerStatus:
     timestamp: str = ''
 
@@ -346,7 +346,7 @@ class ControllerStatus:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class ModelStatus:
     name: str
     type: str
@@ -372,7 +372,7 @@ class ModelStatus:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class NetworkInterface:
     ip_addresses: list[str]
     mac_address: str
@@ -394,7 +394,7 @@ class NetworkInterface:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class LxdProfileContents:
     config: dict[str, str]
     description: str
@@ -409,7 +409,7 @@ class LxdProfileContents:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class MachineStatus:
     juju_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
     hostname: str = ''
@@ -452,7 +452,7 @@ class MachineStatus:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class RemoteEndpoint:
     interface: str
     role: str
@@ -465,7 +465,7 @@ class RemoteEndpoint:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class RemoteAppStatus:
     url: str
 
@@ -487,7 +487,7 @@ class RemoteAppStatus:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class OfferStatus:
     app: str
     endpoints: dict[str, RemoteEndpoint]
@@ -509,7 +509,7 @@ class OfferStatus:
         )
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class FormattedStatus:
     model: ModelStatus
     machines: dict[str, MachineStatus]

--- a/structs.py
+++ b/structs.py
@@ -89,7 +89,7 @@ class UnitStatus:
             leader=d.get('leader'),
             upgrading_from=d.get('upgrading-from'),
             machine=d.get('machine'),
-            open_ports=[x for x in d['open-ports']] if 'open-ports' in d else None,
+            open_ports=d.get('open-ports'),
             public_address=d.get('public-address'),
             address=d.get('address'),
             provider_id=d.get('provider-id'),
@@ -140,10 +140,10 @@ class AppStatus:
             life=d.get('life'),
             app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
             relations={k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()} if 'relations' in d else None,
-            subordinate_to=[x for x in d['subordinate-to']] if 'subordinate-to' in d else None,
+            subordinate_to=d.get('subordinate-to'),
             units={k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else None,
             version=d.get('version'),
-            endpoint_bindings={k: v for k, v in d['endpoint-bindings'].items()} if 'endpoint-bindings' in d else None,
+            endpoint_bindings=d.get('endpoint-bindings'),
         )
 
 
@@ -409,10 +409,10 @@ class NetworkInterface:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
         return cls(
-            ip_addresses=[x for x in d['ip-addresses']],
+            ip_addresses=d['ip-addresses'],
             mac_address=d['mac-address'],
             gateway=d.get('gateway'),
-            dns_nameservers=[x for x in d['dns-nameservers']] if 'dns-nameservers' in d else None,
+            dns_nameservers=d.get('dns-nameservers'),
             space=d.get('space'),
             is_up=d['is-up'],
         )
@@ -427,9 +427,9 @@ class LxdProfileContents:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
         return cls(
-            config={k: v for k, v in d['config'].items()},
+            config=d['config'],
             description=d['description'],
-            devices={k: {k: v for k, v in v.items()} for k, v in d['devices'].items()},
+            devices=d['devices'],
         )
 
 
@@ -458,7 +458,7 @@ class MachineStatus:
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
             hostname=d.get('hostname'),
             dns_name=d.get('dns-name'),
-            ip_addresses=[x for x in d['ip-addresses']] if 'ip-addresses' in d else None,
+            ip_addresses=d.get('ip-addresses'),
             instance_id=d.get('instance-id'),
             display_name=d.get('display-name'),
             machine_status=StatusInfoContents.from_dict(d['machine-status']) if 'machine-status' in d else None,
@@ -502,7 +502,7 @@ class RemoteAppStatus:
             endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else None,
             life=d.get('life'),
             app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
-            relations={k: [x for x in v] for k, v in d['relations'].items()} if 'relations' in d else None,
+            relations=d.get('relations'),
         )
 
 

--- a/structs.py
+++ b/structs.py
@@ -324,12 +324,12 @@ class FilesystemAttachments:
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FilesystemInfo:
-    attachments: FilesystemAttachments
     size: int
 
     provider_id: str = ''
     volume: str = ''
     storage: str = ''
+    attachments: FilesystemAttachments = dataclasses.field(default_factory=FilesystemAttachments)
     pool: str = ''
     life: str = ''
     status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
@@ -337,11 +337,15 @@ class FilesystemInfo:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
         return cls(
-            attachments=FilesystemAttachments.from_dict(d['Attachments']),
             size=d['size'],
             provider_id=d.get('provider-id') or '',
             volume=d.get('volume') or '',
             storage=d.get('storage') or '',
+            attachments=(
+                FilesystemAttachments.from_dict(d['attachments'])
+                if 'attachments' in d
+                else FilesystemAttachments()
+            ),
             pool=d.get('pool') or '',
             life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),

--- a/structs.py
+++ b/structs.py
@@ -27,6 +27,8 @@ class StatusInfoContents:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
+        if 'status-error' in d:
+            raise Exception(d['status-error'])
         return cls(
             current=d.get('current'),
             message=d.get('message'),
@@ -82,6 +84,8 @@ class UnitStatus:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
+        if 'status-error' in d:
+            raise Exception(d['status-error'])
         return cls(
             workload_status=StatusInfoContents.from_dict(d['workload-status']) if 'workload-status' in d else None,
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
@@ -124,6 +128,8 @@ class AppStatus:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> AppStatus:
+        if 'status-error' in d:
+            raise Exception(d['status-error'])
         return cls(
             charm=d['charm'],
             base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
@@ -462,6 +468,8 @@ class MachineStatus:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> MachineStatus:
+        if 'status-error' in d:
+            raise Exception(d['status-error'])
         return cls(
             juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
             hostname=d.get('hostname'),
@@ -506,6 +514,8 @@ class RemoteAppStatus:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
+        if 'status-error' in d:
+            raise Exception(d['status-error'])
         return cls(
             url=d['url'],
             endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else {},
@@ -526,6 +536,8 @@ class OfferStatus:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
+        if 'status-error' in d:
+            raise Exception(d['status-error'])
         return cls(
             app=d['application'],
             charm=d.get('charm'),

--- a/structs.py
+++ b/structs.py
@@ -159,10 +159,11 @@ class AppStatus:
             raise StatusError(d['status-error'])
         return cls(
             charm=d['charm'],
-            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
             charm_origin=d['charm-origin'],
             charm_name=d['charm-name'],
             charm_rev=d['charm-rev'],
+            exposed=d['exposed'],
+            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
             charm_channel=d.get('charm-channel') or '',
             charm_version=d.get('charm-version') or '',
             charm_profile=d.get('charm-profile') or '',
@@ -170,7 +171,6 @@ class AppStatus:
             scale=d.get('scale') or 0,
             provider_id=d.get('provider-id') or '',
             address=d.get('address') or '',
-            exposed=d['exposed'],
             life=d.get('life') or '',
             app_status=(
                 StatusInfoContents.from_dict(d['application-status'])
@@ -270,9 +270,9 @@ class StorageInfo:
     def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
         return cls(
             kind=d['kind'],
-            life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']),
             persistent=d['persistent'],
+            life=d.get('life') or '',
             attachments=(
                 StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None
             ),
@@ -337,12 +337,12 @@ class FilesystemInfo:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
         return cls(
+            Attachments=FilesystemAttachments.from_dict(d['Attachments']),
+            size=d['size'],
             provider_id=d.get('provider-id') or '',
             volume=d.get('volume') or '',
             storage=d.get('storage') or '',
-            Attachments=FilesystemAttachments.from_dict(d['Attachments']),
             pool=d.get('pool') or '',
-            size=d['size'],
             life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
@@ -360,10 +360,10 @@ class VolumeAttachment:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
         return cls(
+            read_only=d['read-only'],
             device=d.get('device') or '',
             device_link=d.get('device-link') or '',
             bus_address=d.get('bus-address') or '',
-            read_only=d['read-only'],
             life=d.get('life') or '',
         )
 
@@ -412,6 +412,8 @@ class VolumeInfo:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
         return cls(
+            size=d['size'],
+            persistent=d['persistent'],
             provider_id=d.get('provider-id') or '',
             storage=d.get('storage') or '',
             attachments=(
@@ -422,8 +424,6 @@ class VolumeInfo:
             pool=d.get('pool') or '',
             hardware_id=d.get('hardware-id') or '',
             wwn=d.get('wwn') or '',
-            size=d['size'],
-            persistent=d['persistent'],
             life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
@@ -497,10 +497,10 @@ class NetworkInterface:
         return cls(
             ip_addresses=d['ip-addresses'],
             mac_address=d['mac-address'],
+            is_up=d['is-up'],
             gateway=d.get('gateway') or '',
             dns_nameservers=d.get('dns-nameservers') or [],
             space=d.get('space') or '',
-            is_up=d['is-up'],
         )
 
 
@@ -590,8 +590,8 @@ class ModelStatus:
             type=d['type'],
             controller=d['controller'],
             cloud=d['cloud'],
-            region=d.get('region') or '',
             version=d['version'],
+            region=d.get('region') or '',
             upgrade_available=d.get('upgrade-available') or '',
             model_status=(
                 StatusInfoContents.from_dict(d['model-status'])
@@ -629,10 +629,10 @@ class OfferStatus:
             raise StatusError(d['status-error'])
         return cls(
             app=d['application'],
+            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
             charm=d.get('charm') or '',
             total_connected_count=d.get('total-connected-count') or 0,
             active_connected_count=d.get('active-connected-count') or 0,
-            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
         )
 
 

--- a/structs.py
+++ b/structs.py
@@ -69,9 +69,9 @@ class MeterStatus:
 
 @dataclasses.dataclass(frozen=True)
 class UnitStatus:
-    workload_status: StatusInfoContents | None = None
-    juju_status: StatusInfoContents | None = None
-    meter_status: MeterStatus | None = None
+    workload_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    juju_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    meter_status: MeterStatus = dataclasses.field(default_factory=MeterStatus)
     leader: bool = False
     upgrading_from: str = ''
     machine: str = ''
@@ -87,9 +87,9 @@ class UnitStatus:
         if 'status-error' in d:
             raise Exception(d['status-error'])
         return cls(
-            workload_status=StatusInfoContents.from_dict(d['workload-status']) if 'workload-status' in d else None,
-            juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
-            meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else None,
+            workload_status=StatusInfoContents.from_dict(d['workload-status']) if 'workload-status' in d else StatusInfoContents(),
+            juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else StatusInfoContents(),
+            meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else MeterStatus(),
             leader=d.get('leader') or False,
             upgrading_from=d.get('upgrading-from') or '',
             machine=d.get('machine') or '',
@@ -119,7 +119,7 @@ class AppStatus:
     provider_id: str = ''
     address: str = ''
     life: str = ''
-    app_status: StatusInfoContents | None = None
+    app_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
     relations: dict[str, list[AppStatusRelation]] = dataclasses.field(default_factory=dict)
     subordinate_to: list[str] = dataclasses.field(default_factory=list)
     units: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
@@ -145,7 +145,7 @@ class AppStatus:
             address=d.get('address') or '',
             exposed=d['exposed'],
             life=d.get('life') or '',
-            app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
+            app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else StatusInfoContents(),
             relations={k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()} if 'relations' in d else {},
             subordinate_to=d.get('subordinate-to') or [],
             units={k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {},
@@ -273,7 +273,7 @@ class FilesystemInfo:
     storage: str = ''
     pool: str = ''
     life: str = ''
-    status: EntityStatus | None = None
+    status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
@@ -285,7 +285,7 @@ class FilesystemInfo:
             pool=d.get('pool') or '',
             size=d['size'],
             life=d.get('life') or '',
-            status=EntityStatus.from_dict(d['status']) if 'status' in d else None,
+            status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
 
 
@@ -331,26 +331,26 @@ class VolumeInfo:
 
     provider_id: str = ''
     storage: str = ''
-    attachments: VolumeAttachments | None = None
+    attachments: VolumeAttachments = dataclasses.field(default_factory=VolumeAttachments)
     pool: str = ''
     hardware_id: str = ''
     wwn: str = ''
     life: str = ''
-    status: EntityStatus | None = None
+    status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
         return cls(
             provider_id=d.get('provider-id') or '',
             storage=d.get('storage') or '',
-            attachments=VolumeAttachments.from_dict(d['attachments']) if 'attachments' in d else None,
+            attachments=VolumeAttachments.from_dict(d['attachments']) if 'attachments' in d else VolumeAttachments(),
             pool=d.get('pool') or '',
             hardware_id=d.get('hardware-id') or '',
             wwn=d.get('wwn') or '',
             size=d['size'],
             persistent=d['persistent'],
             life=d.get('life') or '',
-            status=EntityStatus.from_dict(d['status']) if 'status' in d else None,
+            status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
 
 
@@ -390,8 +390,8 @@ class ModelStatus:
 
     region: str = ''
     upgrade_available: str = ''
-    model_status: StatusInfoContents | None = None
-    meter_status: MeterStatus | None = None
+    model_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    meter_status: MeterStatus = dataclasses.field(default_factory=MeterStatus)
     sla: str = ''
 
     @classmethod
@@ -404,8 +404,8 @@ class ModelStatus:
             region=d.get('region') or '',
             version=d['version'],
             upgrade_available=d.get('upgrade-available') or '',
-            model_status=StatusInfoContents.from_dict(d['model-status']) if 'model-status' in d else None,
-            meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else None,
+            model_status=StatusInfoContents.from_dict(d['model-status']) if 'model-status' in d else StatusInfoContents(),
+            meter_status=MeterStatus.from_dict(d['meter-status']) if 'meter-status' in d else MeterStatus(),
             sla=d.get('sla') or '',
         )
 
@@ -449,14 +449,14 @@ class LxdProfileContents:
 
 @dataclasses.dataclass(frozen=True)
 class MachineStatus:
-    juju_status: StatusInfoContents | None = None
+    juju_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
     hostname: str = ''
     dns_name: str = ''
     ip_addresses: list[str] = dataclasses.field(default_factory=list)
     instance_id: str = ''
     display_name: str = ''
-    machine_status: StatusInfoContents | None = None
-    modification_status: StatusInfoContents | None = None
+    machine_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    modification_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
     base: FormattedBase | None = None
     network_interfaces: dict[str, NetworkInterface] = dataclasses.field(default_factory=dict)
     containers: dict[str, MachineStatus] = dataclasses.field(default_factory=dict)
@@ -471,14 +471,14 @@ class MachineStatus:
         if 'status-error' in d:
             raise Exception(d['status-error'])
         return cls(
-            juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else None,
+            juju_status=StatusInfoContents.from_dict(d['juju-status']) if 'juju-status' in d else StatusInfoContents(),
             hostname=d.get('hostname') or '',
             dns_name=d.get('dns-name') or '',
             ip_addresses=d.get('ip-addresses') or [],
             instance_id=d.get('instance-id') or '',
             display_name=d.get('display-name') or '',
-            machine_status=StatusInfoContents.from_dict(d['machine-status']) if 'machine-status' in d else None,
-            modification_status=StatusInfoContents.from_dict(d['modification-status']) if 'modification-status' in d else None,
+            machine_status=StatusInfoContents.from_dict(d['machine-status']) if 'machine-status' in d else StatusInfoContents(),
+            modification_status=StatusInfoContents.from_dict(d['modification-status']) if 'modification-status' in d else StatusInfoContents(),
             base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
             network_interfaces={k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()} if 'network-interfaces' in d else {},
             containers={k: MachineStatus.from_dict(v) for k, v in d['containers'].items()} if 'containers' in d else {},
@@ -509,7 +509,7 @@ class RemoteAppStatus:
 
     endpoints: dict[str, RemoteEndpoint] = dataclasses.field(default_factory=dict)
     life: str = ''
-    app_status: StatusInfoContents | None = None
+    app_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
     relations: dict[str, list[str]] = dataclasses.field(default_factory=dict)
 
     @classmethod
@@ -520,7 +520,7 @@ class RemoteAppStatus:
             url=d['url'],
             endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()} if 'endpoints' in d else {},
             life=d.get('life') or '',
-            app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else None,
+            app_status=StatusInfoContents.from_dict(d['application-status']) if 'application-status' in d else StatusInfoContents(),
             relations=d.get('relations') or {},
         )
 
@@ -555,8 +555,8 @@ class FormattedStatus:
 
     app_endpoints: dict[str, RemoteAppStatus] = dataclasses.field(default_factory=dict)
     offers: dict[str, OfferStatus] = dataclasses.field(default_factory=dict)
-    storage: CombinedStorage | None = None
-    controller: ControllerStatus | None = None
+    storage: CombinedStorage = dataclasses.field(default_factory=CombinedStorage)
+    controller: ControllerStatus = dataclasses.field(default_factory=ControllerStatus)
     branches: dict[str, BranchStatus] = dataclasses.field(default_factory=dict)
 
     @classmethod
@@ -567,7 +567,7 @@ class FormattedStatus:
             apps={k: AppStatus.from_dict(v) for k, v in d['applications'].items()},
             app_endpoints={k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()} if 'application-endpoints' in d else {},
             offers={k: OfferStatus.from_dict(v) for k, v in d['offers'].items()} if 'offers' in d else {},
-            storage=CombinedStorage.from_dict(d['storage']) if 'storage' in d else None,
-            controller=ControllerStatus.from_dict(d['controller']) if 'controller' in d else None,
+            storage=CombinedStorage.from_dict(d['storage']) if 'storage' in d else CombinedStorage(),
+            controller=ControllerStatus.from_dict(d['controller']) if 'controller' in d else ControllerStatus(),
             branches={k: BranchStatus.from_dict(v) for k, v in d['branches'].items()} if 'branches' in d else {},
         )


### PR DESCRIPTION
To generate `structs.py`, run:

```
$ make getfields

# Which is equivalent to:

$ go run ./cmd/getfields/ >structs.py
$ uvx ruff@0.9.6 format --line-length=99 --config "format.quote-style = 'single'" structs.py
```

This is the same as https://github.com/benhoyt/juju/pull/1, but against the Juju `main` (4.0) branch.

Basically some metering stuff was removed. I think we probably want to use the 4.0 branch for the Jubilant types, so these extra fields don't show up in autocomplete -- just the ones common to 3.6 and 4.

[This commit](https://github.com/benhoyt/juju/commit/92dc1c8c93d132f5ee189494123fa91a6b98fa09) shows the diff of the generated `structs.py`.